### PR TITLE
Domains not being cached

### DIFF
--- a/internal/dnsresolver/resolver.go
+++ b/internal/dnsresolver/resolver.go
@@ -586,7 +586,9 @@ func responseTTL(msg *dns.Msg, negativeTTL time.Duration) time.Duration {
 		}
 	}
 	if minTTL == 0 {
-		return 0
+		// For successful responses with no Answer records or TTL=0,
+		// use negativeTTL to cache the response and avoid repeated upstream queries
+		return negativeTTL
 	}
 	return time.Duration(minTTL) * time.Second
 }


### PR DESCRIPTION
Update `responseTTL` to cache successful DNS responses with no answer records using `negativeTTL`.

Previously, `NOERROR` responses with an empty Answer section or TTL=0 were not cached, leading to repeated upstream queries for domains that lack certain record types (e.g., AAAA records for a domain that only has A records). This change ensures these "negative" responses are cached, reducing unnecessary upstream traffic.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-48b14097-ccbb-47ad-9307-24936635bff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48b14097-ccbb-47ad-9307-24936635bff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

