### PR TITLE
Csv export syntax error

### DIFF
--- a/web/server/src/index.js
+++ b/web/server/src/index.js
@@ -181,7 +181,6 @@ export function createApp(options = {}) {
       ${whereClause}
       ORDER BY ${sortBy} ${sortDir}
       LIMIT {limit: UInt32}
-      FORMAT CSVWithNames
     `;
     try {
       const result = await clickhouseClient.query({


### PR DESCRIPTION
Remove duplicate `FORMAT CSVWithNames` from SQL query to fix ClickHouse syntax error.

The `FORMAT CSVWithNames` clause was specified both in the SQL query string and in the ClickHouse client query options, leading to a "Expected one of: SETTINGS, end of query" syntax error.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a542b91c-5b4b-4e83-a7ab-6f05d91b2f46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a542b91c-5b4b-4e83-a7ab-6f05d91b2f46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

