### PR TITLE
Redis db persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /logs
+/data
 /config/config.yaml
 /web/**/node_modules
 /web/**/dist

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,0 +1,2 @@
+# This directory contains persistent data for services
+# The actual data files are ignored by .gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - redis_data:/data
+      - ./data/redis:/data
       - ./config/redis.conf:/etc/redis/redis.conf:ro
 
   clickhouse:
@@ -72,5 +72,4 @@ services:
       - clickhouse
 
 volumes:
-  redis_data:
   clickhouse_data:


### PR DESCRIPTION
Move Redis database to host filesystem for persistence.

Redis data will now persist in the `./data/redis` directory on the host filesystem, ensuring data survives container restarts, removals, and Docker system prunes.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9db3ab67-6faa-4608-9539-f89e18b686ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9db3ab67-6faa-4608-9539-f89e18b686ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

