### PR TITLE
Clickhouse data path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "8123:8123"
       - "9000:9000"
     volumes:
-      - clickhouse_data:/var/lib/clickhouse
+      - ./data/clickhouse:/var/lib/clickhouse
       - ./db/clickhouse/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
 
   metrics-api:
@@ -70,6 +70,3 @@ services:
     depends_on:
       - redis
       - clickhouse
-
-volumes:
-  clickhouse_data:


### PR DESCRIPTION
Move ClickHouse data storage to `./data/clickhouse` for consistency with Redis.

ClickHouse now uses a bind mount to `./data/clickhouse` instead of a Docker named volume, aligning its data storage location with Redis, which uses `./data/redis`. This change simplifies local development setup by centralizing database data under the `data/` directory.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6894575c-f249-46ed-bacf-ca0d9ff8c9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6894575c-f249-46ed-bacf-ca0d9ff8c9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

