### PR TITLE
Add data directory to .dockerignore to fix build permission errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 /.env
 /tmp
 /logs
+/data
 **/.DS_Store
 /web/**/node_modules
 /web/**/dist


### PR DESCRIPTION
The Redis container creates files with its own permissions in data/redis/. Excluding this directory from the Docker build context prevents permission denied errors when building other services.