### PR TITLE
Avg TTL unit change

### DIFF
--- a/web/client/src/App.jsx
+++ b/web/client/src/App.jsx
@@ -799,7 +799,7 @@ export default function App() {
             label="Average TTL"
             value={
               stats?.keyspace?.avgTtlMs
-                ? `${formatNumber(stats?.keyspace?.avgTtlMs)} ms`
+                ? `${formatNumber(Math.round(stats?.keyspace?.avgTtlMs / 1000))} s`
                 : "-"
             }
           />


### PR DESCRIPTION
Convert Avg TTL display from milliseconds to seconds to improve readability in the UI.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-0362bca6-0316-49f6-b07b-88e3ff2816e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0362bca6-0316-49f6-b07b-88e3ff2816e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

