### PR TITLE
Overview page pause options

### DIFF
--- a/cmd/beyond-ads-dns/main.go
+++ b/cmd/beyond-ads-dns/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/tternquist/beyond-ads-dns/internal/blocklist"
@@ -210,6 +211,61 @@ func startControlServer(cfg config.ControlConfig, configPath string, manager *bl
 			"average_per_sweep_24h": stats.AveragePerSweep24h,
 			"sweeps_24h":            stats.Sweeps24h,
 			"refreshed_24h":         stats.Refreshed24h,
+		})
+	})
+	mux.HandleFunc("/blocklists/pause", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if token != "" && !authorize(token, r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var req struct {
+			Duration int `json:"duration_minutes"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid request"})
+			return
+		}
+		if req.Duration <= 0 || req.Duration > 1440 {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "duration must be between 1 and 1440 minutes"})
+			return
+		}
+		duration := time.Duration(req.Duration) * time.Minute
+		manager.Pause(duration)
+		status := manager.PauseStatus()
+		writeJSON(w, http.StatusOK, map[string]any{
+			"paused": status.Paused,
+			"until":  status.Until,
+		})
+	})
+	mux.HandleFunc("/blocklists/resume", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if token != "" && !authorize(token, r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		manager.Resume()
+		writeJSON(w, http.StatusOK, map[string]any{"paused": false})
+	})
+	mux.HandleFunc("/blocklists/pause/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if token != "" && !authorize(token, r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		status := manager.PauseStatus()
+		writeJSON(w, http.StatusOK, map[string]any{
+			"paused": status.Paused,
+			"until":  status.Until,
 		})
 	})
 

--- a/web/server/src/index.js
+++ b/web/server/src/index.js
@@ -546,6 +546,85 @@ export function createApp(options = {}) {
     }
   });
 
+  app.post("/api/blocklists/pause", async (req, res) => {
+    if (!dnsControlUrl) {
+      res.status(400).json({ error: "DNS_CONTROL_URL is not set" });
+      return;
+    }
+    try {
+      const headers = { "Content-Type": "application/json" };
+      if (dnsControlToken) {
+        headers.Authorization = `Bearer ${dnsControlToken}`;
+      }
+      const response = await fetch(`${dnsControlUrl}/blocklists/pause`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(req.body),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        res.status(502).json({ error: body || `Pause failed: ${response.status}` });
+        return;
+      }
+      const data = await response.json();
+      res.json(data);
+    } catch (err) {
+      res.status(500).json({ error: err.message || "Failed to pause blocking" });
+    }
+  });
+
+  app.post("/api/blocklists/resume", async (_req, res) => {
+    if (!dnsControlUrl) {
+      res.status(400).json({ error: "DNS_CONTROL_URL is not set" });
+      return;
+    }
+    try {
+      const headers = {};
+      if (dnsControlToken) {
+        headers.Authorization = `Bearer ${dnsControlToken}`;
+      }
+      const response = await fetch(`${dnsControlUrl}/blocklists/resume`, {
+        method: "POST",
+        headers,
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        res.status(502).json({ error: body || `Resume failed: ${response.status}` });
+        return;
+      }
+      const data = await response.json();
+      res.json(data);
+    } catch (err) {
+      res.status(500).json({ error: err.message || "Failed to resume blocking" });
+    }
+  });
+
+  app.get("/api/blocklists/pause/status", async (_req, res) => {
+    if (!dnsControlUrl) {
+      res.status(400).json({ error: "DNS_CONTROL_URL is not set" });
+      return;
+    }
+    try {
+      const headers = {};
+      if (dnsControlToken) {
+        headers.Authorization = `Bearer ${dnsControlToken}`;
+      }
+      const response = await fetch(`${dnsControlUrl}/blocklists/pause/status`, {
+        method: "GET",
+        headers,
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        res.status(502).json({ error: body || `Status check failed: ${response.status}` });
+        return;
+      }
+      const data = await response.json();
+      res.json(data);
+    } catch (err) {
+      res.status(500).json({ error: err.message || "Failed to get pause status" });
+    }
+  });
+
   const staticDir =
     options.staticDir ||
     process.env.STATIC_DIR ||


### PR DESCRIPTION
Add pause blocking functionality to the overview page with options for 1, 5, 30 minutes, and 1 hour, allowing users to temporarily disable ad blocking.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-aef02216-740a-4f69-b9d0-cde6210cd592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aef02216-740a-4f69-b9d0-cde6210cd592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

