### PR TITLE
Analytics query retention days

### DIFF
--- a/cmd/beyond-ads-dns/main.go
+++ b/cmd/beyond-ads-dns/main.go
@@ -61,6 +61,7 @@ func main() {
 			cfg.QueryStore.Password,
 			cfg.QueryStore.FlushInterval.Duration,
 			cfg.QueryStore.BatchSize,
+			cfg.QueryStore.RetentionDays,
 			logger,
 		)
 		if err != nil {

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -63,6 +63,7 @@ query_store:
   password: "beyondads"
   flush_interval: "5s"
   batch_size: 500
+  retention_days: 7  # Number of days to keep query analytics data
 
 control:
   enabled: true

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -63,6 +63,7 @@ query_store:
   password: "beyondads"
   flush_interval: "5s"
   batch_size: 500
+  retention_days: 7
 
 control:
   enabled: true

--- a/db/clickhouse/init.sql
+++ b/db/clickhouse/init.sql
@@ -14,4 +14,4 @@ CREATE TABLE IF NOT EXISTS beyond_ads.dns_queries
 )
 ENGINE = MergeTree
 ORDER BY (ts, qname)
-TTL ts + INTERVAL 30 DAY;
+TTL ts + INTERVAL 7 DAY;

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,7 @@ type QueryStoreConfig struct {
 	Password      string   `yaml:"password"`
 	FlushInterval Duration `yaml:"flush_interval"`
 	BatchSize     int      `yaml:"batch_size"`
+	RetentionDays int      `yaml:"retention_days"`
 }
 
 type ControlConfig struct {
@@ -291,6 +292,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.QueryStore.BatchSize == 0 {
 		cfg.QueryStore.BatchSize = 500
 	}
+	if cfg.QueryStore.RetentionDays == 0 {
+		cfg.QueryStore.RetentionDays = 7
+	}
 	if cfg.Control.Enabled == nil {
 		cfg.Control.Enabled = boolPtr(false)
 	}
@@ -387,6 +391,9 @@ func validate(cfg *Config) error {
 		}
 		if cfg.QueryStore.BatchSize <= 0 {
 			return fmt.Errorf("query_store.batch_size must be greater than zero")
+		}
+		if cfg.QueryStore.RetentionDays <= 0 {
+			return fmt.Errorf("query_store.retention_days must be greater than zero")
 		}
 	}
 	if cfg.Cache.Refresh.Enabled != nil && *cfg.Cache.Refresh.Enabled {


### PR DESCRIPTION
Make query analytics data retention configurable with a default of 7 days.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f2a78ed0-79f8-4251-a9bd-c6ee9a8158d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2a78ed0-79f8-4251-a9bd-c6ee9a8158d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

