### PR TITLE
Query duration precision

### DIFF
--- a/db/clickhouse/init.sql
+++ b/db/clickhouse/init.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS beyond_ads.dns_queries
     qclass LowCardinality(String),
     outcome LowCardinality(String),
     rcode LowCardinality(String),
-    duration_ms UInt32
+    duration_ms Float64
 )
 ENGINE = MergeTree
 ORDER BY (ts, qname)

--- a/internal/dnsresolver/resolver.go
+++ b/internal/dnsresolver/resolver.go
@@ -653,9 +653,10 @@ func (r *Resolver) logRequest(w dns.ResponseWriter, question dns.Question, outco
 			rcode = fmt.Sprintf("%d", response.Rcode)
 		}
 	}
+	durationMS := duration.Seconds() * 1000.0
 	if r.requestLogger != nil {
-		r.requestLogger.Printf("client=%s protocol=%s qname=%s qtype=%s qclass=%s outcome=%s rcode=%s duration_ms=%d",
-			clientAddr, protocol, qname, qtype, qclass, outcome, rcode, duration.Milliseconds())
+		r.requestLogger.Printf("client=%s protocol=%s qname=%s qtype=%s qclass=%s outcome=%s rcode=%s duration_ms=%.2f",
+			clientAddr, protocol, qname, qtype, qclass, outcome, rcode, durationMS)
 	}
 	if r.queryStore != nil {
 		r.queryStore.Record(querystore.Event{
@@ -667,7 +668,7 @@ func (r *Resolver) logRequest(w dns.ResponseWriter, question dns.Question, outco
 			QClass:     qclass,
 			Outcome:    outcome,
 			RCode:      rcode,
-			DurationMS: duration.Milliseconds(),
+			DurationMS: durationMS,
 		})
 	}
 }

--- a/internal/querystore/store.go
+++ b/internal/querystore/store.go
@@ -11,7 +11,7 @@ type Event struct {
 	QClass     string
 	Outcome    string
 	RCode      string
-	DurationMS int64
+	DurationMS float64
 }
 
 type Store interface {

--- a/web/client/src/App.jsx
+++ b/web/client/src/App.jsx
@@ -915,37 +915,37 @@ export default function App() {
             <StatCard
               label="Avg"
               value={
-                queryLatency?.avgMs ? `${formatNumber(queryLatency.avgMs)} ms` : "-"
+                queryLatency?.avgMs != null ? `${queryLatency.avgMs.toFixed(2)} ms` : "-"
               }
             />
             <StatCard
               label="P50"
               value={
-                queryLatency?.p50Ms ? `${formatNumber(queryLatency.p50Ms)} ms` : "-"
+                queryLatency?.p50Ms != null ? `${queryLatency.p50Ms.toFixed(2)} ms` : "-"
               }
             />
             <StatCard
               label="P95"
               value={
-                queryLatency?.p95Ms ? `${formatNumber(queryLatency.p95Ms)} ms` : "-"
+                queryLatency?.p95Ms != null ? `${queryLatency.p95Ms.toFixed(2)} ms` : "-"
               }
             />
             <StatCard
               label="P99"
               value={
-                queryLatency?.p99Ms ? `${formatNumber(queryLatency.p99Ms)} ms` : "-"
+                queryLatency?.p99Ms != null ? `${queryLatency.p99Ms.toFixed(2)} ms` : "-"
               }
             />
             <StatCard
               label="Min"
               value={
-                queryLatency?.minMs ? `${formatNumber(queryLatency.minMs)} ms` : "-"
+                queryLatency?.minMs != null ? `${queryLatency.minMs.toFixed(2)} ms` : "-"
               }
             />
             <StatCard
               label="Max"
               value={
-                queryLatency?.maxMs ? `${formatNumber(queryLatency.maxMs)} ms` : "-"
+                queryLatency?.maxMs != null ? `${queryLatency.maxMs.toFixed(2)} ms` : "-"
               }
             />
           </div>
@@ -1165,7 +1165,7 @@ export default function App() {
                 <span>{row.qtype || "-"}</span>
                 <span>{row.outcome || "-"}</span>
                 <span>{row.rcode || "-"}</span>
-                <span>{row.duration_ms ? `${row.duration_ms} ms` : "-"}</span>
+                <span>{row.duration_ms != null ? `${Number(row.duration_ms).toFixed(2)} ms` : "-"}</span>
               </div>
             ))}
             <div className="table-footer">


### PR DESCRIPTION
Add 2 decimal places of precision to query durations to accurately display sub-millisecond values.

Previously, query durations under 1ms were rounded to 0 due to `UInt32` storage in ClickHouse and `int64` handling in the backend, causing the UI to display them as "-". This PR updates the database schema to `Float64`, the backend to calculate `float64` durations, and the frontend to display these values with two decimal places, providing more useful performance metrics.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f67740d3-aba1-4a61-94c3-365abaa048e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f67740d3-aba1-4a61-94c3-365abaa048e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

