### PR TITLE
Add ClickHouse migration script for duration_ms Float64 conversion

### DIFF
--- a/db/clickhouse/MIGRATION.md
+++ b/db/clickhouse/MIGRATION.md
@@ -1,0 +1,52 @@
+# ClickHouse Schema Migration
+
+## Duration Precision Update
+
+### Problem
+If you're seeing all query durations as `0.00 ms` after upgrading, it's because the existing ClickHouse table still has the old `UInt32` column type for `duration_ms`. The backend is now sending Float64 values with decimal precision, but they're being truncated to integers.
+
+### Solution
+
+Run the migration script to update the column type:
+
+```bash
+# Option 1: Using clickhouse-client
+clickhouse-client --query="$(cat db/clickhouse/migrate_duration_to_float64.sql)"
+
+# Option 2: Using docker exec (if running in Docker)
+docker exec -i clickhouse-server clickhouse-client < db/clickhouse/migrate_duration_to_float64.sql
+
+# Option 3: Using HTTP API
+curl 'http://localhost:8123/' --data-binary @db/clickhouse/migrate_duration_to_float64.sql
+```
+
+### Verification
+
+After running the migration, verify the column type:
+
+```sql
+DESCRIBE beyond_ads.dns_queries;
+```
+
+You should see `duration_ms Float64` instead of `duration_ms UInt32`.
+
+### About Precision
+
+**2 decimal places = 0.01ms = 10 microseconds**
+
+This precision level is sufficient for DNS queries because:
+- **Cache hits**: Typically 0.10-0.50 ms (will show as 0.10-0.50 ms)
+- **Upstream queries**: Typically 5-50 ms (will show full precision)
+- **Very fast queries**: Even sub-0.01ms queries will show as 0.00 ms, which is acceptable
+
+### Alternative: Recreate Table
+
+If you don't have important historical data, you can drop and recreate the table:
+
+```sql
+DROP TABLE IF EXISTS beyond_ads.dns_queries;
+```
+
+Then restart the application - the `init.sql` will create the table with the correct schema.
+
+**⚠️ Warning**: This will delete all existing query history!

--- a/db/clickhouse/check_schema.sql
+++ b/db/clickhouse/check_schema.sql
@@ -1,0 +1,13 @@
+-- Check if the duration_ms column needs migration
+-- If this shows UInt32, you need to run the migration
+-- If this shows Float64, the migration is complete
+
+SELECT 
+    name,
+    type,
+    comment
+FROM system.columns
+WHERE 
+    database = 'beyond_ads' 
+    AND table = 'dns_queries' 
+    AND name = 'duration_ms';

--- a/db/clickhouse/migrate_duration_to_float64.sql
+++ b/db/clickhouse/migrate_duration_to_float64.sql
@@ -1,0 +1,10 @@
+-- Migration script to update duration_ms column from UInt32 to Float64
+-- This is needed for existing tables to support sub-millisecond precision
+
+-- Step 1: Alter the table to change the column type
+ALTER TABLE beyond_ads.dns_queries 
+MODIFY COLUMN duration_ms Float64;
+
+-- Note: ClickHouse will automatically handle the type conversion
+-- Existing integer values (0, 1, 2, etc.) will become 0.0, 1.0, 2.0, etc.
+-- New values with decimal precision will be stored correctly


### PR DESCRIPTION
- Added migration script to alter existing tables from UInt32 to Float64
- Added MIGRATION.md with detailed instructions and troubleshooting
- Added check_schema.sql to verify column type

This addresses the issue where existing deployments see 0.00ms for all queries because the table schema wasn't automatically updated.