### PR TITLE
Docker compose metrics port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "53:53/udp"
       - "53:53/tcp"
+      - "8081:8081"
     volumes:
       - ./config:/etc/beyond-ads-dns:ro
       - ./logs:/app/logs


### PR DESCRIPTION
Expose port 8081 in docker-compose for accessing DNS service metrics.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6f3f15bf-4362-40cc-9328-1970df7c2ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f3f15bf-4362-40cc-9328-1970df7c2ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

