### PR TITLE
Reported numbers accuracy

### DIFF
--- a/cmd/beyond-ads-dns/main.go
+++ b/cmd/beyond-ads-dns/main.go
@@ -230,6 +230,22 @@ func startControlServer(cfg config.ControlConfig, configPath string, manager *bl
 		stats := resolver.CacheStats()
 		writeJSONAny(w, http.StatusOK, stats)
 	})
+	mux.HandleFunc("/querystore/stats", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if token != "" && !authorize(token, r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if resolver == nil {
+			writeJSONAny(w, http.StatusOK, map[string]any{})
+			return
+		}
+		stats := resolver.QueryStoreStats()
+		writeJSONAny(w, http.StatusOK, stats)
+	})
 	mux.HandleFunc("/blocklists/pause", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/dnsresolver/resolver.go
+++ b/internal/dnsresolver/resolver.go
@@ -375,6 +375,13 @@ func (r *Resolver) CacheStats() cache.CacheStats {
 	return r.cache.GetCacheStats()
 }
 
+func (r *Resolver) QueryStoreStats() querystore.StoreStats {
+	if r.queryStore == nil {
+		return querystore.StoreStats{}
+	}
+	return r.queryStore.Stats()
+}
+
 func (s *refreshStats) record(count int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/querystore/store.go
+++ b/internal/querystore/store.go
@@ -17,4 +17,12 @@ type Event struct {
 type Store interface {
 	Record(event Event)
 	Close() error
+	Stats() StoreStats
+}
+
+type StoreStats struct {
+	BufferSize    int    `json:"buffer_size"`
+	BufferUsed    int    `json:"buffer_used"`
+	DroppedEvents uint64 `json:"dropped_events"`
+	TotalRecorded uint64 `json:"total_recorded"`
 }


### PR DESCRIPTION
Increases ClickHouse query store buffer size and adds monitoring for dropped events to fix inaccurate query logging.

The previous buffer size was insufficient for high L0 cache throughput (500K-1M queries/second), causing query events to be silently dropped and leading to significant discrepancies in reported numbers. This PR ensures all queries are logged and provides visibility into buffer performance.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8e64e77b-458a-4679-b2bb-f90b9efa7469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e64e77b-458a-4679-b2bb-f90b9efa7469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

