### PR TITLE
Overview cache statistics

### DIFF
--- a/web/server/src/index.js
+++ b/web/server/src/index.js
@@ -625,6 +625,32 @@ export function createApp(options = {}) {
     }
   });
 
+  app.get("/api/cache/stats", async (_req, res) => {
+    if (!dnsControlUrl) {
+      res.status(400).json({ error: "DNS_CONTROL_URL is not set" });
+      return;
+    }
+    try {
+      const headers = {};
+      if (dnsControlToken) {
+        headers.Authorization = `Bearer ${dnsControlToken}`;
+      }
+      const response = await fetch(`${dnsControlUrl}/cache/stats`, {
+        method: "GET",
+        headers,
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        res.status(502).json({ error: body || `Cache stats failed: ${response.status}` });
+        return;
+      }
+      const data = await response.json();
+      res.json(data);
+    } catch (err) {
+      res.status(500).json({ error: err.message || "Failed to load cache stats" });
+    }
+  });
+
   const staticDir =
     options.staticDir ||
     process.env.STATIC_DIR ||


### PR DESCRIPTION
Add L0, L1, and L2 cache statistics to the Overview page to provide better visibility into the caching layers.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-fd66c425-e1c7-49ea-81dd-02fe819a52db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd66c425-e1c7-49ea-81dd-02fe819a52db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

