### PR TITLE
Fix revokeSyncToken call to use correct token index parameter

### DIFF
--- a/web/client/src/pages/SyncPage.jsx
+++ b/web/client/src/pages/SyncPage.jsx
@@ -258,7 +258,7 @@ export default function SyncPage() {
                         <td>
                           <button
                             className="button"
-                            onClick={() => revokeSyncToken(t.id)}
+                            onClick={() => revokeSyncToken(t.index)}
                             disabled={syncLoading}
                           >
                             Revoke


### PR DESCRIPTION
## Summary
Fixed a bug in the SyncPage component where the revoke sync token button was passing the wrong parameter to the `revokeSyncToken` function.

## Changes
- Updated the `revokeSyncToken` function call to pass `t.index` instead of `t.id` as the parameter

## Details
The revoke button in the sync tokens table was incorrectly using the token's `id` property when the function expects the token's `index` property. This change ensures the correct token is revoked when the user clicks the revoke button.

https://claude.ai/code/session_01Jewb5vp2CzSqAzCewk7MxS