### PR TITLE
feat: per-group disable_cache flag to bypass cache to upstream

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,11 +147,12 @@ type DNSAffectingConfig struct {
 
 // syncClientGroupConfig is the sync payload for client groups (includes blocklist for Phase 3, safe_search for Phase 4).
 type syncClientGroupConfig struct {
-	ID          string                   `json:"id"`
-	Name        string                   `json:"name"`
-	Description string                   `json:"description"`
-	Blocklist   *syncGroupBlocklistConfig `json:"blocklist,omitempty"`
-	SafeSearch  *syncSafeSearchConfig     `json:"safe_search,omitempty"`
+	ID           string                    `json:"id"`
+	Name         string                    `json:"name"`
+	Description  string                    `json:"description"`
+	Blocklist    *syncGroupBlocklistConfig `json:"blocklist,omitempty"`
+	SafeSearch   *syncSafeSearchConfig     `json:"safe_search,omitempty"`
+	DisableCache *bool                     `json:"disable_cache,omitempty"`
 }
 
 type syncGroupBlocklistConfig struct {
@@ -212,11 +213,12 @@ func (c *Config) DNSAffecting() DNSAffectingConfig {
 			}
 		}
 		clientGroups = append(clientGroups, syncClientGroupConfig{
-			ID:          g.ID,
-			Name:        g.Name,
-			Description: g.Description,
-			Blocklist:   bl,
-			SafeSearch:  ss,
+			ID:           g.ID,
+			Name:         g.Name,
+			Description:  g.Description,
+			Blocklist:    bl,
+			SafeSearch:   ss,
+			DisableCache: g.DisableCache,
 		})
 	}
 	return DNSAffectingConfig{
@@ -560,6 +562,10 @@ type ClientGroup struct {
 	Description string                 `yaml:"description"`
 	Blocklist   *GroupBlocklistConfig   `yaml:"blocklist"`
 	SafeSearch  *SafeSearchConfig       `yaml:"safe_search"` // Phase 4: per-group safe search override
+	// DisableCache, when true, bypasses the DNS cache for clients in this group.
+	// Queries pass through directly to upstream on every request and responses are not cached.
+	// Nil or false = use cache normally.
+	DisableCache *bool `yaml:"disable_cache"`
 }
 
 // HasCustomBlocklist returns true if the group has its own blocklist (inherit_global: false).

--- a/internal/control/client_groups.go
+++ b/internal/control/client_groups.go
@@ -71,6 +71,9 @@ func handleClientGroupsList(w http.ResponseWriter, configPath string) {
 				"bing":    g.SafeSearch.Bing,
 			}
 		}
+		if g.DisableCache != nil {
+			grp["disable_cache"] = *g.DisableCache
+		}
 		groups = append(groups, grp)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"client_groups": groups})
@@ -98,11 +101,12 @@ func groupBlocklistToMap(bl *config.GroupBlocklistConfig) map[string]any {
 
 func handleClientGroupsCreateOrUpdate(w http.ResponseWriter, r *http.Request, resolver *dnsresolver.Resolver, configPath string) {
 	var body struct {
-		ID          string                 `json:"id"`
-		Name        string                 `json:"name"`
-		Description string                 `json:"description"`
-		Blocklist   map[string]any         `json:"blocklist"`
-		SafeSearch  map[string]any         `json:"safe_search"`
+		ID           string         `json:"id"`
+		Name         string         `json:"name"`
+		Description  string         `json:"description"`
+		Blocklist    map[string]any `json:"blocklist"`
+		SafeSearch   map[string]any `json:"safe_search"`
+		DisableCache *bool          `json:"disable_cache"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON: " + err.Error()})
@@ -136,14 +140,14 @@ func handleClientGroupsCreateOrUpdate(w http.ResponseWriter, r *http.Request, re
 		}
 		id, _ := m["id"].(string)
 		if id == body.ID {
-			groups = append(groups, buildGroupMap(body.ID, body.Name, body.Description, body.Blocklist, body.SafeSearch))
+			groups = append(groups, buildGroupMap(body.ID, body.Name, body.Description, body.Blocklist, body.SafeSearch, body.DisableCache))
 			found = true
 		} else {
 			groups = append(groups, m)
 		}
 	}
 	if !found {
-		groups = append(groups, buildGroupMap(body.ID, body.Name, body.Description, body.Blocklist, body.SafeSearch))
+		groups = append(groups, buildGroupMap(body.ID, body.Name, body.Description, body.Blocklist, body.SafeSearch, body.DisableCache))
 	}
 	override["client_groups"] = groups
 	if err := config.WriteOverrideMap(configPath, override); err != nil {
@@ -153,13 +157,16 @@ func handleClientGroupsCreateOrUpdate(w http.ResponseWriter, r *http.Request, re
 	reloadClientGroups(w, resolver, configPath)
 }
 
-func buildGroupMap(id, name, desc string, blocklist, safeSearch map[string]any) map[string]any {
+func buildGroupMap(id, name, desc string, blocklist, safeSearch map[string]any, disableCache *bool) map[string]any {
 	m := map[string]any{"id": id, "name": name, "description": desc}
 	if len(blocklist) > 0 {
 		m["blocklist"] = blocklist
 	}
 	if len(safeSearch) > 0 {
 		m["safe_search"] = safeSearch
+	}
+	if disableCache != nil {
+		m["disable_cache"] = *disableCache
 	}
 	return m
 }
@@ -218,6 +225,7 @@ func reloadClientGroups(w http.ResponseWriter, resolver *dnsresolver.Resolver, c
 		resolver.ApplyClientIdentificationConfig(cfg)
 		resolver.ApplyBlocklistConfig(context.Background(), cfg)
 		resolver.ApplySafeSearchConfig(cfg)
+		resolver.ApplyGroupCacheControl(cfg)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -672,6 +672,7 @@ func handleClientIdentificationReload(resolver *dnsresolver.Resolver, configPath
 		if resolver != nil {
 			resolver.ApplyClientIdentificationConfig(cfg)
 			resolver.ApplyBlocklistConfig(r.Context(), cfg)
+			resolver.ApplyGroupCacheControl(cfg)
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 	}

--- a/internal/dnsresolver/resolver.go
+++ b/internal/dnsresolver/resolver.go
@@ -105,6 +105,10 @@ type Resolver struct {
 	safeSearchMap      map[string]string            // global: qname (lower) -> CNAME target
 	groupSafeSearchMap map[string]map[string]string // per-group override (Phase 4)
 	groupNoSafeSearch  map[string]bool              // groups with SafeSearch.Enabled=false (explicit disable)
+	// groupCacheDisabled: groups with disable_cache=true. Queries from clients in these groups
+	// bypass the DNS cache entirely (no lookup, no write) and pass through to upstream.
+	groupCacheDisabledMu sync.RWMutex
+	groupCacheDisabled   map[string]bool
 	traceEvents        atomic.Pointer[tracelog.Events] // runtime-configurable trace events
 }
 
@@ -381,11 +385,14 @@ func New(cfg config.Config, cacheClient cache.DNSCache, localRecordsManager *loc
 		}
 	}
 
+	groupCacheDisabled := buildGroupCacheDisabled(cfg)
+
 	r := &Resolver{
 		cache:                cacheClient,
 		localRecords:         localRecordsManager,
 		blocklist:            blocklistManager,
 		groupBlocklists:      groupBlocklists,
+		groupCacheDisabled:   groupCacheDisabled,
 		upstreamMgr:         newUpstreamManager(upstreams, strategy, netCfg.timeout, netCfg.backoff, netCfg.connPoolIdle, netCfg.connPoolValidate),
 		minTTL:           cfg.Cache.MinTTL.Duration,
 		maxTTL:           cfg.Cache.MaxTTL.Duration,
@@ -602,7 +609,8 @@ func (r *Resolver) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 
 	cacheKey := cacheKey(qname, question.Qtype, question.Qclass)
-	if r.cache != nil {
+	cacheDisabled := r.isCacheDisabledForClient(w)
+	if r.cache != nil && !cacheDisabled {
 		cacheLookupStart := time.Now()
 		cached, ttl, storedTTL, authTTL, err := r.cache.GetWithTTL(context.Background(), cacheKey)
 		cacheLookupDuration := time.Since(cacheLookupStart)
@@ -763,7 +771,7 @@ func (r *Resolver) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		tracelog.Trace(te, r.logger, tracelog.EventQueryResolution, "query resolution", "outcome", "upstream", "qname", qname, "qtype", qtypeStr, "upstream", upstreamAddr, "duration_ms", time.Since(start).Milliseconds())
 	}
 
-	if r.cache != nil && ttl > 0 {
+	if r.cache != nil && !cacheDisabled && ttl > 0 {
 		key, resp, ttlVal, authTTLVal := cacheKey, response, ttl, authTTL
 		go func() {
 			if err := r.cacheSet(context.Background(), key, resp, ttlVal, authTTLVal); err != nil {
@@ -1422,6 +1430,44 @@ func (r *Resolver) isBlockedForClient(w dns.ResponseWriter, qname string) bool {
 	return blMgr.IsBlocked(qname)
 }
 
+// buildGroupCacheDisabled returns the set of group IDs whose clients should bypass the DNS cache.
+func buildGroupCacheDisabled(cfg config.Config) map[string]bool {
+	m := make(map[string]bool)
+	for _, g := range cfg.ClientGroups {
+		if g.DisableCache != nil && *g.DisableCache {
+			m[g.ID] = true
+		}
+	}
+	return m
+}
+
+// isCacheDisabledForClient reports whether the client's group has cache disabled.
+// Returns false (cache enabled) when no groups disable cache, or when the client has no group.
+// Performance: skips client/group resolution when no groups disable cache.
+func (r *Resolver) isCacheDisabledForClient(w dns.ResponseWriter) bool {
+	r.groupCacheDisabledMu.RLock()
+	empty := len(r.groupCacheDisabled) == 0
+	r.groupCacheDisabledMu.RUnlock()
+	if empty {
+		return false
+	}
+	if !r.clientIDEnabled.Load() || r.clientIDResolver == nil {
+		return false
+	}
+	clientAddr := clientIPFromWriter(w)
+	if clientAddr == "" {
+		return false
+	}
+	groupID := r.clientIDResolver.ResolveGroup(clientAddr)
+	if groupID == "" {
+		return false
+	}
+	r.groupCacheDisabledMu.RLock()
+	disabled := r.groupCacheDisabled[groupID]
+	r.groupCacheDisabledMu.RUnlock()
+	return disabled
+}
+
 // clientIPFromWriter extracts the client IP from dns.ResponseWriter, stripping port if present.
 // Returns empty string if w is nil or RemoteAddr is nil.
 func clientIPFromWriter(w dns.ResponseWriter) string {
@@ -1523,6 +1569,14 @@ func (r *Resolver) ApplyResponseConfig(cfg config.Config) {
 	r.blockedResponse = blocked
 	r.blockedTTL = ttl
 	r.responseMu.Unlock()
+}
+
+// ApplyGroupCacheControl updates the per-group disable_cache map at runtime (for hot-reload and sync).
+func (r *Resolver) ApplyGroupCacheControl(cfg config.Config) {
+	next := buildGroupCacheDisabled(cfg)
+	r.groupCacheDisabledMu.Lock()
+	r.groupCacheDisabled = next
+	r.groupCacheDisabledMu.Unlock()
 }
 
 // ApplyBlocklistConfig updates per-group blocklist managers at runtime (for hot-reload and sync).

--- a/internal/dnsresolver/resolver_test.go
+++ b/internal/dnsresolver/resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -3295,6 +3296,150 @@ func TestResolverPerGroupBlocklist(t *testing.T) {
 	}
 	if w3.written.Rcode != dns.RcodeNameError {
 		t.Errorf("unidentified client query ads.example.com: Rcode = %s, want NXDOMAIN", dns.RcodeToString[w3.written.Rcode])
+	}
+}
+
+// TestResolverGroupDisableCache verifies that clients in a group with disable_cache=true
+// bypass the cache (no lookup, no write) and pass through directly to upstream.
+func TestResolverGroupDisableCache(t *testing.T) {
+	blCfg := config.BlocklistConfig{
+		RefreshInterval: config.Duration{Duration: time.Hour},
+		Sources:         []config.BlocklistSource{},
+	}
+	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
+	blMgr.LoadOnce(nil)
+
+	var upstreamCount int
+	var upstreamMu sync.Mutex
+	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamMu.Lock()
+		upstreamCount++
+		upstreamMu.Unlock()
+		body, _ := io.ReadAll(r.Body)
+		req := new(dns.Msg)
+		_ = req.Unpack(body)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Authoritative = true
+		resp.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.IPv4(93, 184, 216, 34),
+			},
+		}
+		packed, _ := resp.Pack()
+		w.Header().Set("Content-Type", "application/dns-message")
+		_, _ = w.Write(packed)
+	})
+	dohSrv := newHTTPServer(dohHandler)
+	defer dohSrv.Close()
+
+	mockCache := cache.NewMockCache()
+	// Pre-populate the cache: if cache is used, this entry is returned without
+	// hitting upstream. A disable_cache client should bypass it.
+	cachedResp := new(dns.Msg)
+	cachedResp.SetQuestion("example.com.", dns.TypeA)
+	cachedResp.Authoritative = true
+	cachedResp.Answer = []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+			A:   net.IPv4(192, 168, 1, 100),
+		},
+	}
+	mockCache.SetEntry(cacheKey("example.com", dns.TypeA, dns.ClassINET), cachedResp, 5*time.Minute)
+
+	cfg := minimalResolverConfig(dohSrv.URL)
+	cfg.Upstreams = []config.UpstreamConfig{{Name: "doh", Address: dohSrv.URL, Protocol: "https"}}
+	cfg.Blocklists = blCfg
+	cfg.ClientIdentification = config.ClientIdentificationConfig{
+		Enabled: ptr(true),
+		Clients: config.ClientEntries{
+			{IP: "192.168.1.10", Name: "No-Cache Device", GroupID: "nocache"},
+			{IP: "192.168.1.11", Name: "Cached Device", GroupID: "normal"},
+		},
+	}
+	cfg.ClientGroups = []config.ClientGroup{
+		{ID: "nocache", Name: "No Cache", DisableCache: ptr(true)},
+		{ID: "normal", Name: "Normal"},
+	}
+
+	resolver := buildTestResolver(t, cfg, mockCache, blMgr, nil)
+
+	// Normal group client: cache hit → upstream not called, response from cache (192.168.1.100)
+	req1 := new(dns.Msg)
+	req1.SetQuestion("example.com.", dns.TypeA)
+	w1 := &mockResponseWriter{remoteAddr: "192.168.1.11"}
+	resolver.ServeDNS(w1, req1)
+	upstreamMu.Lock()
+	if upstreamCount != 0 {
+		t.Errorf("normal group: expected cache hit (0 upstream calls), got %d", upstreamCount)
+	}
+	upstreamMu.Unlock()
+	if w1.written == nil || len(w1.written.Answer) == 0 {
+		t.Fatal("normal group: expected cached response")
+	}
+	if a, ok := w1.written.Answer[0].(*dns.A); !ok || !a.A.Equal(net.IPv4(192, 168, 1, 100)) {
+		t.Errorf("normal group: expected cached A 192.168.1.100, got %v", w1.written.Answer)
+	}
+
+	// No-cache group client: bypass cache → upstream called, response from upstream (93.184.216.34)
+	req2 := new(dns.Msg)
+	req2.SetQuestion("example.com.", dns.TypeA)
+	w2 := &mockResponseWriter{remoteAddr: "192.168.1.10"}
+	resolver.ServeDNS(w2, req2)
+	upstreamMu.Lock()
+	gotUpstream := upstreamCount
+	upstreamMu.Unlock()
+	if gotUpstream != 1 {
+		t.Errorf("no-cache group: expected 1 upstream call (cache bypass), got %d", gotUpstream)
+	}
+	if w2.written == nil || len(w2.written.Answer) == 0 {
+		t.Fatal("no-cache group: expected upstream response")
+	}
+	if a, ok := w2.written.Answer[0].(*dns.A); !ok || !a.A.Equal(net.IPv4(93, 184, 216, 34)) {
+		t.Errorf("no-cache group: expected upstream A 93.184.216.34, got %v", w2.written.Answer)
+	}
+
+	// Verify no-cache response was not written back to cache: entry count unchanged
+	// (background cache write goroutine would increment it).
+	time.Sleep(50 * time.Millisecond)
+	if mockCache.EntryCount() != 1 {
+		t.Errorf("no-cache group: expected cache entry count to remain 1 (write bypassed), got %d", mockCache.EntryCount())
+	}
+}
+
+// TestResolverApplyGroupCacheControl verifies that disable_cache can be toggled at runtime.
+func TestResolverApplyGroupCacheControl(t *testing.T) {
+	blCfg := config.BlocklistConfig{
+		RefreshInterval: config.Duration{Duration: time.Hour},
+		Sources:         []config.BlocklistSource{},
+	}
+	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
+	blMgr.LoadOnce(nil)
+
+	cfg := minimalResolverConfig("https://invalid.invalid/dns-query")
+	cfg.ClientIdentification = config.ClientIdentificationConfig{
+		Enabled: ptr(true),
+		Clients: config.ClientEntries{{IP: "192.168.1.10", Name: "Device", GroupID: "g1"}},
+	}
+	cfg.ClientGroups = []config.ClientGroup{{ID: "g1", Name: "G1"}}
+	resolver := buildTestResolver(t, cfg, nil, blMgr, nil)
+
+	w := &mockResponseWriter{remoteAddr: "192.168.1.10"}
+	if resolver.isCacheDisabledForClient(w) {
+		t.Fatal("initially expected cache enabled for group g1")
+	}
+
+	cfg.ClientGroups[0].DisableCache = ptr(true)
+	resolver.ApplyGroupCacheControl(cfg)
+	if !resolver.isCacheDisabledForClient(w) {
+		t.Fatal("after ApplyGroupCacheControl(disable=true) expected cache disabled for group g1")
+	}
+
+	cfg.ClientGroups[0].DisableCache = ptr(false)
+	resolver.ApplyGroupCacheControl(cfg)
+	if resolver.isCacheDisabledForClient(w) {
+		t.Fatal("after ApplyGroupCacheControl(disable=false) expected cache enabled for group g1")
 	}
 }
 

--- a/internal/sync/client.go
+++ b/internal/sync/client.go
@@ -162,6 +162,7 @@ func (c *Client) sync(ctx context.Context) error {
 		c.resolver.ApplySafeSearchConfig(fullCfg)
 		c.resolver.ApplyClientIdentificationConfig(fullCfg)
 		c.resolver.ApplyBlocklistConfig(ctx, fullCfg)
+		c.resolver.ApplyGroupCacheControl(fullCfg)
 	}
 
 	c.logger.Debug("sync: config applied successfully")
@@ -413,6 +414,9 @@ func (c *Client) mergeAndWrite(payload config.DNSAffectingConfig) error {
 				if len(ss) > 0 {
 					grp["safe_search"] = ss
 				}
+			}
+			if g.DisableCache != nil {
+				grp["disable_cache"] = *g.DisableCache
 			}
 			clientGroups = append(clientGroups, grp)
 		}


### PR DESCRIPTION
Adds a disable_cache flag on ClientGroup. When true, DNS queries from
clients in that group skip the cache entirely (no lookup, no write) and
pass through directly to upstream on every request. Other groups continue
using the cache normally. Hot-reloadable via the control API and synced
to replicas.

https://claude.ai/code/session_016jcTcAMrgLkRUvbeuP947E