### PR TITLE
ci: use GitHub-hosted runners for amd64 jobs

### DIFF
--- a/.github/workflows/appliance-tag.yml
+++ b/.github/workflows/appliance-tag.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   promote-appliance:
-    runs-on: [self-hosted, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: Validate and normalize version
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,15 +19,6 @@ jobs:
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Set Go cache environment (self-hosted)
-        if: steps.gomod.outputs.found == 'true'
-        run: |
-          HOME="${HOME:-/home/github-runner}"
-          echo "HOME=$HOME" >> "$GITHUB_ENV"
-          echo "GOPATH=$HOME/go" >> "$GITHUB_ENV"
-          echo "GOMODCACHE=$HOME/go/pkg/mod" >> "$GITHUB_ENV"
-          echo "GOCACHE=$HOME/.cache/go-build" >> "$GITHUB_ENV"
 
       - name: Set up Go
         if: steps.gomod.outputs.found == 'true'

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - platform: linux/amd64
             suffix: amd64
-            runner: [self-hosted, amd64]
+            runner: ubuntu-latest
           - platform: linux/arm64
             suffix: arm64
             runner: [self-hosted, ARM64]
@@ -75,7 +75,7 @@ jobs:
 
   merge:
     needs: build
-    runs-on: [self-hosted, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: [self-hosted, amd64]
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -107,7 +107,7 @@ jobs:
         include:
           - platform: linux/amd64
             suffix: amd64
-            runner: [self-hosted, amd64]
+            runner: ubuntu-latest
           - platform: linux/arm64
             suffix: arm64
             runner: [self-hosted, ARM64]
@@ -149,7 +149,7 @@ jobs:
 
   docker-merge:
     needs: [release, docker-build]
-    runs-on: [self-hosted, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/stable-tag.yml
+++ b/.github/workflows/stable-tag.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   promote-stable:
-    runs-on: [self-hosted, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: Validate and normalize version
         id: version


### PR DESCRIPTION
Replace self-hosted amd64 runners with ubuntu-latest across CI, release,
GHCR publish, and stable/appliance promotion workflows. ARM64 jobs still
use the self-hosted ARM64 runner. Drops the self-hosted-specific Go cache
bootstrap step since actions/setup-go handles caching on hosted runners.