### PR TITLE
feat: group disable_cache toggle in web UI

### DIFF
--- a/web/client/src/pages/ClientsPage.jsx
+++ b/web/client/src/pages/ClientsPage.jsx
@@ -851,6 +851,32 @@ export default function ClientsPage() {
               </div>
             )}
           </div>
+          <div className="form-group" style={{ marginTop: "1rem" }}>
+            <label className="field-label">Cache</label>
+            <p className="muted" style={{ marginTop: 0, marginBottom: 8 }}>
+              When disabled, queries from devices in this group bypass the DNS cache
+              and go directly to upstream resolvers on every request.
+            </p>
+            <label className="checkbox">
+              <input
+                type="checkbox"
+                checked={g.disable_cache === true}
+                onChange={(e) => {
+                  const groups = [...(systemConfig.client_groups || [])];
+                  const next = { ...groups[i] };
+                  if (e.target.checked) {
+                    next.disable_cache = true;
+                  } else {
+                    delete next.disable_cache;
+                  }
+                  groups[i] = next;
+                  updateSystemConfig("client_groups", null, groups);
+                }}
+                disabled={readOnly}
+              />
+              Disable cache for this group
+            </label>
+          </div>
           {g.id !== "default" && (
             <button
               type="button"


### PR DESCRIPTION
## Summary
- Adds a "Disable cache for this group" checkbox to the group edit form on the Clients page
- Backend for `disable_cache` landed in 5aa4078 but the React UI was never updated, so the flag couldn't be toggled from the web interface
- Unchecking deletes the key (rather than writing `false`) to keep the override YAML clean and match the backend's nil-means-cache-enabled semantic

## Test plan
- [ ] Open a group on the Clients page, verify the new "Cache" section appears below Safe Search
- [ ] Check the box, save, confirm `disable_cache: true` is written to the override config and replicas sync
- [ ] Uncheck, save, confirm the key is removed from the group in the override config
- [ ] Verify queries from a client in that group bypass the cache when toggled on (and use cache when toggled off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)