### PR TITLE
Add CI race detector + coverage, test querystore retention/partition guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Run Go tests
         if: steps.gomod.outputs.found == 'true'
-        run: go test ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      - name: Report Go coverage
+        if: steps.gomod.outputs.found == 'true'
+        run: go tool cover -func=coverage.out | tail -1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/cmd/beyond-ads-dns/main_test.go
+++ b/cmd/beyond-ads-dns/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestRunSetAdminPassword_FromArg(t *testing.T) {
+	// Write into a nested path under a temp dir to also exercise MkdirAll.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets", ".admin-password")
+	t.Setenv("ADMIN_PASSWORD_FILE", path)
+
+	if err := runSetAdminPassword([]string{"hunter2"}); err != nil {
+		t.Fatalf("runSetAdminPassword: %v", err)
+	}
+
+	hash, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading password file: %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword(hash, []byte("hunter2")); err != nil {
+		t.Errorf("stored hash does not verify against password: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("password file perms = %o, want 600", perm)
+	}
+}
+
+func TestRunSetAdminPassword_TrimsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".admin-password")
+	t.Setenv("ADMIN_PASSWORD_FILE", path)
+
+	if err := runSetAdminPassword([]string{"  spaced  "}); err != nil {
+		t.Fatalf("runSetAdminPassword: %v", err)
+	}
+	hash, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading password file: %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword(hash, []byte("spaced")); err != nil {
+		t.Errorf("trimmed password should verify: %v", err)
+	}
+}
+
+func TestRunSetAdminPassword_EmptyFromStdin(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ADMIN_PASSWORD_FILE", filepath.Join(dir, ".admin-password"))
+
+	// No arg provided and stdin is empty: it should fail rather than write an
+	// empty-password file.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	w.Close() // immediate EOF, no input
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	if err := runSetAdminPassword(nil); err == nil {
+		t.Error("expected error when no password is provided")
+	}
+}
+
+func TestRunSetAdminPassword_BlankFromStdin(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ADMIN_PASSWORD_FILE", filepath.Join(dir, ".admin-password"))
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("   \n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	w.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	if err := runSetAdminPassword(nil); err == nil {
+		t.Error("expected error when password is blank after trimming")
+	}
+}

--- a/internal/cache/redis_getpath_test.go
+++ b/internal/cache/redis_getpath_test.go
@@ -1,0 +1,254 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/miekg/dns"
+	"github.com/redis/go-redis/v9"
+	"github.com/tternquist/beyond-ads-dns/internal/config"
+)
+
+// newGetPathCache spins up a miniredis-backed cache with L0 enabled.
+func newGetPathCache(t *testing.T) (*RedisCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	cfg := config.RedisConfig{
+		Mode:    "standalone",
+		Address: mr.Addr(),
+		LRUSize: 100,
+	}
+	c, err := NewRedisCache(cfg, nil)
+	if err != nil {
+		mr.Close()
+		t.Fatalf("NewRedisCache: %v", err)
+	}
+	t.Cleanup(func() {
+		c.Close()
+		mr.Close()
+	})
+	return c, mr
+}
+
+func answerMsg(name string) *dns.Msg {
+	msg := new(dns.Msg)
+	msg.SetQuestion(name, dns.TypeA)
+	msg.Response = true
+	rr, _ := dns.NewRR(name + " 300 IN A 93.184.216.34")
+	msg.Answer = []dns.RR{rr}
+	return msg
+}
+
+func TestRedisCacheGet_HitMissExpired(t *testing.T) {
+	c, _ := newGetPathCache(t)
+	ctx := context.Background()
+
+	// Miss: key not present.
+	got, err := c.Get(ctx, "dns:absent")
+	if err != nil {
+		t.Fatalf("Get(absent): %v", err)
+	}
+	if got != nil {
+		t.Errorf("Get(absent) = %v, want nil", got)
+	}
+
+	// Hit: written via the hash setter (exercises getHash read path).
+	key := "dns:example.com.|A"
+	if err := c.SetWithIndex(ctx, key, answerMsg("example.com."), 5*time.Minute, 0); err != nil {
+		t.Fatalf("SetWithIndex: %v", err)
+	}
+	got, err = c.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get(hit): %v", err)
+	}
+	if got == nil || len(got.Answer) != 1 {
+		t.Fatalf("Get(hit) = %v, want msg with 1 answer", got)
+	}
+	c.ReleaseMsg(got)
+}
+
+func TestRedisCacheGet_WrongTypeMigratesLegacyEntry(t *testing.T) {
+	c, _ := newGetPathCache(t)
+	ctx := context.Background()
+
+	// A legacy entry is a plain string value (not a hash). getHash returns
+	// WRONGTYPE, so Get falls back to getLegacy and migrates it to a hash.
+	key := "dns:legacy.example.|A"
+	if err := c.Set(ctx, key, answerMsg("legacy.example."), 5*time.Minute); err != nil {
+		t.Fatalf("Set(legacy): %v", err)
+	}
+
+	got, err := c.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get(legacy): %v", err)
+	}
+	if got == nil || len(got.Answer) != 1 {
+		t.Fatalf("Get(legacy) = %v, want migrated msg", got)
+	}
+	c.ReleaseMsg(got)
+
+	// After migration the key should now be a hash and still readable.
+	got2, err := c.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get(after-migrate): %v", err)
+	}
+	if got2 == nil || len(got2.Answer) != 1 {
+		t.Fatalf("Get(after-migrate) = %v, want hash msg", got2)
+	}
+	c.ReleaseMsg(got2)
+}
+
+func TestIsWrongType(t *testing.T) {
+	if isWrongType(nil) {
+		t.Error("isWrongType(nil) = true, want false")
+	}
+	if isWrongType(errors.New("some other error")) {
+		t.Error("isWrongType(other) = true, want false")
+	}
+	if !isWrongType(errors.New("WRONGTYPE Operation against a key holding the wrong kind of value")) {
+		t.Error("isWrongType(WRONGTYPE) = false, want true")
+	}
+}
+
+func TestRedisCacheTTL(t *testing.T) {
+	c, _ := newGetPathCache(t)
+	ctx := context.Background()
+
+	key := "dns:ttl.example.|A"
+	if err := c.SetWithIndex(ctx, key, answerMsg("ttl.example."), 5*time.Minute, 0); err != nil {
+		t.Fatalf("SetWithIndex: %v", err)
+	}
+	ttl, err := c.TTL(ctx, key)
+	if err != nil {
+		t.Fatalf("TTL: %v", err)
+	}
+	// The Redis key TTL is the soft TTL plus the grace period, so it only
+	// needs to be positive for a freshly written entry.
+	if ttl <= 0 {
+		t.Errorf("TTL = %v, want > 0", ttl)
+	}
+
+	// Missing key: redis returns a negative TTL, surfaced as-is (no error).
+	if _, err := c.TTL(ctx, "dns:nope"); err != nil {
+		t.Errorf("TTL(missing): unexpected error %v", err)
+	}
+}
+
+func TestRedisCacheGetCreatedAt(t *testing.T) {
+	c, _ := newGetPathCache(t)
+	ctx := context.Background()
+
+	key := "dns:created.example.|A"
+	if err := c.SetWithIndex(ctx, key, answerMsg("created.example."), 5*time.Minute, 0); err != nil {
+		t.Fatalf("SetWithIndex: %v", err)
+	}
+	ts, err := c.getCreatedAt(ctx, key)
+	if err != nil {
+		t.Fatalf("getCreatedAt: %v", err)
+	}
+	if ts.IsZero() {
+		t.Error("getCreatedAt = zero, want a timestamp for a freshly written entry")
+	}
+
+	// Missing key returns zero time, no error.
+	ts, err = c.getCreatedAt(ctx, "dns:missing")
+	if err != nil {
+		t.Fatalf("getCreatedAt(missing): %v", err)
+	}
+	if !ts.IsZero() {
+		t.Errorf("getCreatedAt(missing) = %v, want zero", ts)
+	}
+}
+
+func TestRedisCacheRefreshLock(t *testing.T) {
+	c, _ := newGetPathCache(t)
+	ctx := context.Background()
+
+	key := "dns:refresh.example.|A"
+
+	ok, err := c.TryAcquireRefresh(ctx, key, time.Second)
+	if err != nil {
+		t.Fatalf("TryAcquireRefresh(first): %v", err)
+	}
+	if !ok {
+		t.Fatal("TryAcquireRefresh(first) = false, want true")
+	}
+
+	// Second acquire while held must fail.
+	ok, err = c.TryAcquireRefresh(ctx, key, time.Second)
+	if err != nil {
+		t.Fatalf("TryAcquireRefresh(second): %v", err)
+	}
+	if ok {
+		t.Error("TryAcquireRefresh(second) = true, want false (lock held)")
+	}
+
+	// After release the lock is acquirable again.
+	c.ReleaseRefresh(ctx, key)
+	ok, err = c.TryAcquireRefresh(ctx, key, time.Second)
+	if err != nil {
+		t.Fatalf("TryAcquireRefresh(after release): %v", err)
+	}
+	if !ok {
+		t.Error("TryAcquireRefresh(after release) = false, want true")
+	}
+}
+
+func TestRedisCacheRemoveFromIndex(t *testing.T) {
+	c, mr := newGetPathCache(t)
+	ctx := context.Background()
+
+	key := "dns:index.example.|A"
+	if err := c.SetWithIndex(ctx, key, answerMsg("index.example."), 5*time.Minute, 0); err != nil {
+		t.Fatalf("SetWithIndex: %v", err)
+	}
+	idxKey := c.expiryIndexKey()
+	if n, _ := mr.ZMembers(idxKey); len(n) != 1 {
+		t.Fatalf("expiry index members = %d, want 1", len(n))
+	}
+
+	c.RemoveFromIndex(ctx, key)
+	if members, _ := mr.ZMembers(idxKey); len(members) != 0 {
+		t.Errorf("expiry index members after remove = %d, want 0", len(members))
+	}
+}
+
+func TestRedisCacheSetMaxKeys(t *testing.T) {
+	c, _ := newGetPathCache(t)
+	c.SetMaxKeys(42)
+	if got := c.GetCacheStats().RedisMaxKeys; got != 42 {
+		t.Errorf("RedisMaxKeys after SetMaxKeys = %d, want 42", got)
+	}
+}
+
+func TestRedisCacheLRUStatsAndClean(t *testing.T) {
+	c, _ := newGetPathCache(t)
+	ctx := context.Background()
+
+	// Populate L0 with a short-lived entry, then a long-lived one.
+	c.SetWithIndex(ctx, "dns:short|A", answerMsg("short."), time.Second, 0)
+	c.SetWithIndex(ctx, "dns:long|A", answerMsg("long."), 5*time.Minute, 0)
+
+	stats := c.GetLRUStats()
+	if stats == nil {
+		t.Fatal("GetLRUStats = nil, want stats (L0 enabled)")
+	}
+
+	// CleanLRUCache returns count of expired entries removed; non-negative always.
+	if n := c.CleanLRUCache(); n < 0 {
+		t.Errorf("CleanLRUCache = %d, want >= 0", n)
+	}
+}
+
+// Sanity: a nil client surfaced as redis.Nil is not treated as WRONGTYPE.
+func TestIsWrongType_RedisNil(t *testing.T) {
+	if isWrongType(redis.Nil) {
+		t.Error("isWrongType(redis.Nil) = true, want false")
+	}
+}

--- a/internal/control/server_handlers_test.go
+++ b/internal/control/server_handlers_test.go
@@ -1,0 +1,107 @@
+package control
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tternquist/beyond-ads-dns/internal/cache"
+	"github.com/tternquist/beyond-ads-dns/internal/config"
+	"github.com/tternquist/beyond-ads-dns/internal/dnsresolver"
+	"github.com/tternquist/beyond-ads-dns/internal/localrecords"
+	"github.com/tternquist/beyond-ads-dns/internal/logging"
+	"github.com/tternquist/beyond-ads-dns/internal/metrics"
+	"github.com/tternquist/beyond-ads-dns/internal/requestlog"
+)
+
+func newHandlerTestResolver() *dnsresolver.Resolver {
+	reqLog := requestlog.NewWriter(&bytes.Buffer{}, "text")
+	return dnsresolver.New(config.Config{}, cache.NewMockCache(),
+		localrecords.New(nil, logging.NewDiscardLogger()), nil,
+		logging.NewDiscardLogger(), reqLog, nil)
+}
+
+func TestHandleMetrics_ServesPrometheus(t *testing.T) {
+	metrics.Init() // idempotent; required so Registry() is non-nil
+
+	// nil resolver path: still serves the registry without panicking.
+	handler := handleMetrics(nil)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nil resolver: status = %d, want 200", rec.Code)
+	}
+
+	// With a resolver, gauges get updated and the body contains Prometheus output.
+	handler = handleMetrics(newHandlerTestResolver())
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("with resolver: status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/plain") {
+		t.Errorf("Content-Type = %q, want prometheus text/plain", ct)
+	}
+}
+
+func TestHandleCacheConfig(t *testing.T) {
+	resolver := newHandlerTestResolver()
+
+	t.Run("rejects GET with 405", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handleCacheConfig(resolver, "").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/cache/config", nil))
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d, want 405", rec.Code)
+		}
+	})
+
+	t.Run("rejects bad token with 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/cache/config", strings.NewReader(`{"max_keys":10}`))
+		req.Header.Set("Authorization", "Bearer wrong")
+		rec := httptest.NewRecorder()
+		handleCacheConfig(resolver, "secret").ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("rejects invalid JSON with 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/cache/config", strings.NewReader(`not json`))
+		rec := httptest.NewRecorder()
+		handleCacheConfig(resolver, "").ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("applies valid max_keys with 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/cache/config", strings.NewReader(`{"max_keys":500}`))
+		rec := httptest.NewRecorder()
+		handleCacheConfig(resolver, "").ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("clamps negative max_keys and returns 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPatch, "/cache/config", strings.NewReader(`{"max_keys":-5}`))
+		rec := httptest.NewRecorder()
+		handleCacheConfig(resolver, "").ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("nil resolver is a safe 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/cache/config", strings.NewReader(`{"max_keys":10}`))
+		rec := httptest.NewRecorder()
+		handleCacheConfig(nil, "").ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+	})
+}

--- a/internal/dnsresolver/resolver_apply_test.go
+++ b/internal/dnsresolver/resolver_apply_test.go
@@ -1,0 +1,210 @@
+package dnsresolver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/tternquist/beyond-ads-dns/internal/cache"
+	"github.com/tternquist/beyond-ads-dns/internal/config"
+	"github.com/tternquist/beyond-ads-dns/internal/querystore"
+	"github.com/tternquist/beyond-ads-dns/internal/tracelog"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// fakeQueryStore is a minimal querystore.Store for QueryStoreStats wiring.
+type fakeQueryStore struct{ stats querystore.StoreStats }
+
+func (f *fakeQueryStore) Record(querystore.Event) {}
+func (f *fakeQueryStore) Close() error            { return nil }
+func (f *fakeQueryStore) Stats() querystore.StoreStats { return f.stats }
+
+func TestApplyUpstreamConfig(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+
+	cfg := config.Config{
+		ResolverStrategy: "load_balance",
+		Upstreams: []config.UpstreamConfig{
+			{Name: "a", Address: "1.1.1.1:53", Protocol: "udp"},
+			{Name: "b", Address: "8.8.8.8:53", Protocol: "udp"},
+		},
+	}
+	r.ApplyUpstreamConfig(cfg)
+
+	ups, strategy := r.UpstreamConfig()
+	if len(ups) != 2 {
+		t.Fatalf("UpstreamConfig got %d upstreams, want 2", len(ups))
+	}
+	if strategy != StrategyLoadBalance {
+		t.Errorf("strategy = %q, want %q", strategy, StrategyLoadBalance)
+	}
+}
+
+func TestApplyUpstreamConfig_InvalidStrategyFallsBackToFailover(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+	r.ApplyUpstreamConfig(config.Config{
+		ResolverStrategy: "nonsense",
+		Upstreams:        []config.UpstreamConfig{{Name: "a", Address: "1.1.1.1:53", Protocol: "udp"}},
+	})
+	if _, strategy := r.UpstreamConfig(); strategy != StrategyFailover {
+		t.Errorf("strategy = %q, want fallback %q", strategy, StrategyFailover)
+	}
+}
+
+func TestApplySafeSearchConfig(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+
+	r.ApplySafeSearchConfig(config.Config{
+		SafeSearch: config.SafeSearchConfig{Enabled: boolPtr(true), Google: boolPtr(true), Bing: boolPtr(true)},
+	})
+
+	r.safeSearchMu.RLock()
+	target, ok := r.safeSearchMap["www.google.com"]
+	r.safeSearchMu.RUnlock()
+	if !ok || target != "forcesafesearch.google.com" {
+		t.Errorf("safeSearchMap[www.google.com] = %q (ok=%v), want forcesafesearch.google.com", target, ok)
+	}
+
+	// Disabling clears the map.
+	r.ApplySafeSearchConfig(config.Config{
+		SafeSearch: config.SafeSearchConfig{Enabled: boolPtr(false)},
+	})
+	r.safeSearchMu.RLock()
+	n := len(r.safeSearchMap)
+	r.safeSearchMu.RUnlock()
+	if n != 0 {
+		t.Errorf("safeSearchMap size after disable = %d, want 0", n)
+	}
+}
+
+func TestApplyResponseConfig(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+
+	r.ApplyResponseConfig(config.Config{
+		Response: config.ResponseConfig{Blocked: "0.0.0.0", BlockedTTL: config.Duration{Duration: 30 * time.Second}},
+	})
+	r.responseMu.RLock()
+	gotResp, gotTTL := r.blockedResponse, r.blockedTTL
+	r.responseMu.RUnlock()
+	if gotResp != "0.0.0.0" || gotTTL != 30*time.Second {
+		t.Errorf("blockedResponse=%q ttl=%v, want 0.0.0.0/30s", gotResp, gotTTL)
+	}
+
+	// Empty values fall back to defaults (nxdomain, 1h).
+	r.ApplyResponseConfig(config.Config{})
+	r.responseMu.RLock()
+	gotResp, gotTTL = r.blockedResponse, r.blockedTTL
+	r.responseMu.RUnlock()
+	if gotResp != "nxdomain" || gotTTL != time.Hour {
+		t.Errorf("defaults: blockedResponse=%q ttl=%v, want nxdomain/1h", gotResp, gotTTL)
+	}
+}
+
+func TestApplyCacheMaxKeys(t *testing.T) {
+	mc := cache.NewMockCache()
+	r := buildTestResolverInternal(config.Config{}, mc, nil, nil)
+	// MockCache implements CacheWithConfig; this should not panic and is a no-op assertion.
+	r.ApplyCacheMaxKeys(123)
+
+	// With a nil cache it must be a safe no-op.
+	rNil := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+	rNil.ApplyCacheMaxKeys(5)
+}
+
+func TestQueryStoreStats(t *testing.T) {
+	fqs := &fakeQueryStore{stats: querystore.StoreStats{BufferSize: 10, TotalRecorded: 7}}
+	r := buildTestResolverWithQueryStore(config.Config{}, nil, nil, nil, fqs)
+	got := r.QueryStoreStats()
+	if got.BufferSize != 10 || got.TotalRecorded != 7 {
+		t.Errorf("QueryStoreStats = %+v, want BufferSize=10 TotalRecorded=7", got)
+	}
+
+	// Nil query store yields a zero-value struct.
+	rNil := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+	if (rNil.QueryStoreStats() != querystore.StoreStats{}) {
+		t.Error("QueryStoreStats with nil store should be zero value")
+	}
+}
+
+func TestSetTraceEvents(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+	ev := tracelog.New([]string{"example.com"})
+	r.SetTraceEvents(ev)
+	if got := r.traceEvents.Load(); got != ev {
+		t.Errorf("traceEvents.Load() = %v, want the events we stored", got)
+	}
+}
+
+func TestServfailReply(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	resp := r.servfailReply(req)
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Errorf("servfailReply rcode = %d, want SERVFAIL (%d)", resp.Rcode, dns.RcodeServerFailure)
+	}
+	if resp.Id != req.Id {
+		t.Errorf("servfailReply id = %d, want %d (matched to request)", resp.Id, req.Id)
+	}
+}
+
+func TestSafeSearchReply(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+	req := new(dns.Msg)
+	q := dns.Question{Name: "www.google.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	req.Question = []dns.Question{q}
+
+	resp := r.safeSearchReply(req, q, "forcesafesearch.google.com")
+	if len(resp.Answer) != 1 {
+		t.Fatalf("safeSearchReply answers = %d, want 1", len(resp.Answer))
+	}
+	cname, ok := resp.Answer[0].(*dns.CNAME)
+	if !ok {
+		t.Fatalf("answer type = %T, want *dns.CNAME", resp.Answer[0])
+	}
+	if cname.Target != "forcesafesearch.google.com." {
+		t.Errorf("CNAME target = %q, want forcesafesearch.google.com.", cname.Target)
+	}
+	if cname.Hdr.Name != "www.google.com." {
+		t.Errorf("CNAME name = %q, want www.google.com.", cname.Hdr.Name)
+	}
+}
+
+func TestApplyBlocklistConfig_GroupManagers(t *testing.T) {
+	r := buildTestResolverInternal(config.Config{}, nil, nil, nil)
+	ctx := context.Background()
+
+	cfg := config.Config{
+		Blocklists: config.BlocklistConfig{RefreshInterval: config.Duration{Duration: time.Hour}},
+		ClientGroups: []config.ClientGroup{
+			{
+				ID: "kids",
+				Blocklist: &config.GroupBlocklistConfig{
+					InheritGlobal: boolPtr(false),
+					Denylist:      []string{"ads.example.com"},
+				},
+			},
+		},
+	}
+	r.ApplyBlocklistConfig(ctx, cfg)
+
+	r.groupBlocklistsMu.RLock()
+	mgr, ok := r.groupBlocklists["kids"]
+	r.groupBlocklistsMu.RUnlock()
+	if !ok || mgr == nil {
+		t.Fatal("expected a group blocklist manager for group 'kids'")
+	}
+
+	// Re-applying with no groups clears the managers.
+	r.ApplyBlocklistConfig(ctx, config.Config{
+		Blocklists: config.BlocklistConfig{RefreshInterval: config.Duration{Duration: time.Hour}},
+	})
+	r.groupBlocklistsMu.RLock()
+	n := len(r.groupBlocklists)
+	r.groupBlocklistsMu.RUnlock()
+	if n != 0 {
+		t.Errorf("group blocklists after clearing = %d, want 0", n)
+	}
+}

--- a/internal/dnsresolver/resolver_apply_test.go
+++ b/internal/dnsresolver/resolver_apply_test.go
@@ -17,8 +17,8 @@ func boolPtr(b bool) *bool { return &b }
 // fakeQueryStore is a minimal querystore.Store for QueryStoreStats wiring.
 type fakeQueryStore struct{ stats querystore.StoreStats }
 
-func (f *fakeQueryStore) Record(querystore.Event) {}
-func (f *fakeQueryStore) Close() error            { return nil }
+func (f *fakeQueryStore) Record(querystore.Event)      {}
+func (f *fakeQueryStore) Close() error                 { return nil }
 func (f *fakeQueryStore) Stats() querystore.StoreStats { return f.stats }
 
 func TestApplyUpstreamConfig(t *testing.T) {

--- a/internal/dnsresolver/resolver_test.go
+++ b/internal/dnsresolver/resolver_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -582,9 +583,9 @@ func TestUpstreamBackoffFailover(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var failCount, okCount int
+	var failCount, okCount atomic.Int32
 	failHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		failCount++
+		failCount.Add(1)
 		http.Error(w, "upstream down", 500)
 	})
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -606,7 +607,7 @@ func TestUpstreamBackoffFailover(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		okCount++
+		okCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 
@@ -639,20 +640,20 @@ func TestUpstreamBackoffFailover(t *testing.T) {
 
 	// Query 1: tries fail (1), then ok (1)
 	doQuery()
-	if failCount != 1 {
-		t.Errorf("after first query: failCount = %d, want 1", failCount)
+	if failCount.Load() != 1 {
+		t.Errorf("after first query: failCount = %d, want 1", failCount.Load())
 	}
-	if okCount != 1 {
-		t.Errorf("after first query: okCount = %d, want 1", okCount)
+	if okCount.Load() != 1 {
+		t.Errorf("after first query: okCount = %d, want 1", okCount.Load())
 	}
 
 	// Query 2 (within backoff): skips fail, tries ok only
 	doQuery()
-	if failCount != 1 {
-		t.Errorf("after second query (in backoff): failCount = %d, want 1 (should skip failed upstream)", failCount)
+	if failCount.Load() != 1 {
+		t.Errorf("after second query (in backoff): failCount = %d, want 1 (should skip failed upstream)", failCount.Load())
 	}
-	if okCount != 2 {
-		t.Errorf("after second query: okCount = %d, want 2", okCount)
+	if okCount.Load() != 2 {
+		t.Errorf("after second query: okCount = %d, want 2", okCount.Load())
 	}
 
 	// Wait for backoff to expire
@@ -660,11 +661,11 @@ func TestUpstreamBackoffFailover(t *testing.T) {
 
 	// Query 3 (after backoff): tries fail again (2), then ok (3)
 	doQuery()
-	if failCount != 2 {
-		t.Errorf("after third query (backoff expired): failCount = %d, want 2", failCount)
+	if failCount.Load() != 2 {
+		t.Errorf("after third query (backoff expired): failCount = %d, want 2", failCount.Load())
 	}
-	if okCount != 3 {
-		t.Errorf("after third query: okCount = %d, want 3", okCount)
+	if okCount.Load() != 3 {
+		t.Errorf("after third query: okCount = %d, want 3", okCount.Load())
 	}
 }
 
@@ -677,9 +678,9 @@ func TestUpstreamBackoffDisabled(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var failCount int
+	var failCount atomic.Int32
 	failHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		failCount++
+		failCount.Add(1)
 		http.Error(w, "upstream down", 500)
 	})
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -734,8 +735,8 @@ func TestUpstreamBackoffDisabled(t *testing.T) {
 	doQuery()
 	doQuery()
 	// With backoff disabled, fail upstream is tried every query
-	if failCount != 2 {
-		t.Errorf("with backoff disabled: failCount = %d, want 2 (retried each query)", failCount)
+	if failCount.Load() != 2 {
+		t.Errorf("with backoff disabled: failCount = %d, want 2 (retried each query)", failCount.Load())
 	}
 }
 
@@ -863,9 +864,9 @@ func TestRefreshUsesUpstreamBackoff(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var failCount, okCount int
+	var failCount, okCount atomic.Int32
 	failHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		failCount++
+		failCount.Add(1)
 		http.Error(w, "upstream down", 500)
 	})
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -887,7 +888,7 @@ func TestRefreshUsesUpstreamBackoff(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		okCount++
+		okCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 
@@ -913,8 +914,8 @@ func TestRefreshUsesUpstreamBackoff(t *testing.T) {
 	req.Id = 12345
 	w := &mockResponseWriter{}
 	resolver.ServeDNS(w, req)
-	if failCount != 1 || okCount != 1 {
-		t.Fatalf("after ServeDNS: failCount=%d okCount=%d, want 1,1", failCount, okCount)
+	if failCount.Load() != 1 || okCount.Load() != 1 {
+		t.Fatalf("after ServeDNS: failCount=%d okCount=%d, want 1,1", failCount.Load(), okCount.Load())
 	}
 
 	// refreshCache uses r.exchange() - should skip fail (in backoff), use ok
@@ -922,11 +923,11 @@ func TestRefreshUsesUpstreamBackoff(t *testing.T) {
 	resolver.refreshCache(q, cacheKey("example.com", dns.TypeA, dns.ClassINET), false, false, false)
 
 	// fail should still be 1 (skipped), ok should be 2
-	if failCount != 1 {
-		t.Errorf("after refreshCache: failCount = %d, want 1 (refresh should skip failed upstream in backoff)", failCount)
+	if failCount.Load() != 1 {
+		t.Errorf("after refreshCache: failCount = %d, want 1 (refresh should skip failed upstream in backoff)", failCount.Load())
 	}
-	if okCount != 2 {
-		t.Errorf("after refreshCache: okCount = %d, want 2", okCount)
+	if okCount.Load() != 2 {
+		t.Errorf("after refreshCache: okCount = %d, want 2", okCount.Load())
 	}
 }
 
@@ -990,7 +991,7 @@ func TestUpstreamBackoffAllProtocols(t *testing.T) {
 	blMgr.LoadOnce(nil)
 
 	// DoH ok handler (used for DoH test and as fallback for TLS test)
-	var dohOkCount int
+	var dohOkCount atomic.Int32
 	dohOkHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -1010,7 +1011,7 @@ func TestUpstreamBackoffAllProtocols(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		dohOkCount++
+		dohOkCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohOkSrv := newHTTPServer(dohOkHandler)
@@ -1078,9 +1079,9 @@ func TestUpstreamBackoffAllProtocols(t *testing.T) {
 
 	for _, proto := range protocols {
 		t.Run(proto.name, func(t *testing.T) {
-			var failCount int
+			var failCount atomic.Int32
 			failHandler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-				failCount++
+				failCount.Add(1)
 				// Write garbage so client Unpack fails
 				_, _ = w.Write([]byte("invalid"))
 			})
@@ -1112,7 +1113,7 @@ func TestUpstreamBackoffAllProtocols(t *testing.T) {
 				proto.fail.Address = "quic://127.0.0.1:1"
 			case "https":
 				failSrv := newHTTPServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					failCount++
+					failCount.Add(1)
 					http.Error(w, "upstream down", 500)
 				}))
 				defer failSrv.Close()
@@ -1142,19 +1143,19 @@ func TestUpstreamBackoffAllProtocols(t *testing.T) {
 			}
 
 			doQuery()
-			if !proto.skipFailCountCheck && failCount != 1 {
-				t.Errorf("after first query: failCount = %d, want 1", failCount)
+			if !proto.skipFailCountCheck && failCount.Load() != 1 {
+				t.Errorf("after first query: failCount = %d, want 1", failCount.Load())
 			}
 
 			doQuery()
-			if !proto.skipFailCountCheck && failCount != 1 {
-				t.Errorf("after second query (in backoff): failCount = %d, want 1 (should skip failed upstream)", failCount)
+			if !proto.skipFailCountCheck && failCount.Load() != 1 {
+				t.Errorf("after second query (in backoff): failCount = %d, want 1 (should skip failed upstream)", failCount.Load())
 			}
 
 			time.Sleep(250 * time.Millisecond)
 			doQuery()
-			if !proto.skipFailCountCheck && failCount != 2 {
-				t.Errorf("after third query (backoff expired): failCount = %d, want 2", failCount)
+			if !proto.skipFailCountCheck && failCount.Load() != 2 {
+				t.Errorf("after third query (backoff expired): failCount = %d, want 2", failCount.Load())
 			}
 		})
 	}
@@ -1198,7 +1199,7 @@ func newDNSServerTCP(t *testing.T, handler dns.Handler) string {
 
 // newTLSFailServer starts a plain TCP server (no TLS). When clients connect with DoT,
 // the TLS handshake fails. Returns tls://addr for use as upstream. Counts connections in failCount.
-func newTLSFailServer(t *testing.T, failCount *int) string {
+func newTLSFailServer(t *testing.T, failCount *atomic.Int32) string {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -1211,7 +1212,7 @@ func newTLSFailServer(t *testing.T, failCount *int) string {
 			if err != nil {
 				return
 			}
-			*failCount++
+			failCount.Add(1)
 			_ = conn.Close()
 		}
 	}()
@@ -1260,9 +1261,9 @@ func TestResolverCacheHit(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var upstreamCount int
+	var upstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamCount++
+		upstreamCount.Add(1)
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
 			return
@@ -1310,8 +1311,8 @@ func TestResolverCacheHit(t *testing.T) {
 	w := &mockResponseWriter{}
 	resolver.ServeDNS(w, req)
 
-	if upstreamCount != 0 {
-		t.Errorf("upstream should not be called on cache hit, got %d calls", upstreamCount)
+	if upstreamCount.Load() != 0 {
+		t.Errorf("upstream should not be called on cache hit, got %d calls", upstreamCount.Load())
 	}
 	if w.written == nil {
 		t.Fatal("expected cached response")
@@ -1784,9 +1785,9 @@ func TestResolverRefusedNotCached(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var upstreamCount int
+	var upstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamCount++
+		upstreamCount.Add(1)
 		body, _ := io.ReadAll(r.Body)
 		req := new(dns.Msg)
 		_ = req.Unpack(body)
@@ -1828,8 +1829,8 @@ func TestResolverRefusedNotCached(t *testing.T) {
 	// REFUSED must not be cached — a second query must hit upstream again
 	w2 := &mockResponseWriter{}
 	resolver.ServeDNS(w2, req)
-	if upstreamCount != 2 {
-		t.Errorf("upstream called %d times, want 2 (REFUSED must not be cached)", upstreamCount)
+	if upstreamCount.Load() != 2 {
+		t.Errorf("upstream called %d times, want 2 (REFUSED must not be cached)", upstreamCount.Load())
 	}
 	if mockCache.EntryCount() != 0 {
 		t.Errorf("cache should be empty after REFUSED, got %d entries", mockCache.EntryCount())
@@ -1920,7 +1921,7 @@ func TestResolverRefreshScheduled(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var refreshUpstreamCount int
+	var refreshUpstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -1940,7 +1941,7 @@ func TestResolverRefreshScheduled(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		refreshUpstreamCount++
+		refreshUpstreamCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohSrv := newHTTPServer(dohHandler)
@@ -1996,8 +1997,8 @@ func TestResolverRefreshScheduled(t *testing.T) {
 
 	// Allow background refresh to run
 	time.Sleep(100 * time.Millisecond)
-	if refreshUpstreamCount < 1 {
-		t.Errorf("expected refresh to call upstream, got %d calls", refreshUpstreamCount)
+	if refreshUpstreamCount.Load() < 1 {
+		t.Errorf("expected refresh to call upstream, got %d calls", refreshUpstreamCount.Load())
 	}
 }
 
@@ -2011,7 +2012,7 @@ func TestResolverRootZoneNoRefresh(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var refreshUpstreamCount int
+	var refreshUpstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -2031,7 +2032,7 @@ func TestResolverRootZoneNoRefresh(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		refreshUpstreamCount++
+		refreshUpstreamCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohSrv := newHTTPServer(dohHandler)
@@ -2087,8 +2088,8 @@ func TestResolverRootZoneNoRefresh(t *testing.T) {
 
 	// Allow time for any background refresh
 	time.Sleep(100 * time.Millisecond)
-	if refreshUpstreamCount != 0 {
-		t.Errorf("root zone should not trigger refresh, got %d upstream calls", refreshUpstreamCount)
+	if refreshUpstreamCount.Load() != 0 {
+		t.Errorf("root zone should not trigger refresh, got %d upstream calls", refreshUpstreamCount.Load())
 	}
 }
 
@@ -2102,7 +2103,7 @@ func TestResolverWarmEntryRefresh(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var refreshUpstreamCount int
+	var refreshUpstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -2122,7 +2123,7 @@ func TestResolverWarmEntryRefresh(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		refreshUpstreamCount++
+		refreshUpstreamCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohSrv := newHTTPServer(dohHandler)
@@ -2177,8 +2178,8 @@ func TestResolverWarmEntryRefresh(t *testing.T) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
-	if refreshUpstreamCount < 1 {
-		t.Errorf("expected warm entry refresh to call upstream (1 hit, 4m TTL <= 5m warm_ttl), got %d calls", refreshUpstreamCount)
+	if refreshUpstreamCount.Load() < 1 {
+		t.Errorf("expected warm entry refresh to call upstream (1 hit, 4m TTL <= 5m warm_ttl), got %d calls", refreshUpstreamCount.Load())
 	}
 }
 
@@ -2192,7 +2193,7 @@ func TestResolverZeroHitsAreNotWarm(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var refreshUpstreamCount int
+	var refreshUpstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -2212,7 +2213,7 @@ func TestResolverZeroHitsAreNotWarm(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		refreshUpstreamCount++
+		refreshUpstreamCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohSrv := newHTTPServer(dohHandler)
@@ -2249,15 +2250,15 @@ func TestResolverZeroHitsAreNotWarm(t *testing.T) {
 	// Remaining TTL is below warm_ttl; with 0 hits this must NOT be considered warm.
 	resolver.maybeRefresh(q, key, 4*time.Minute, 4*time.Minute, 4*time.Minute, 0)
 	time.Sleep(100 * time.Millisecond)
-	if refreshUpstreamCount != 0 {
-		t.Fatalf("expected no refresh for 0 hits (not warm), got %d upstream calls", refreshUpstreamCount)
+	if refreshUpstreamCount.Load() != 0 {
+		t.Fatalf("expected no refresh for 0 hits (not warm), got %d upstream calls", refreshUpstreamCount.Load())
 	}
 
 	// Sanity check: once hits become warm (1), request-driven refresh should run.
 	resolver.maybeRefresh(q, key, 4*time.Minute, 4*time.Minute, 4*time.Minute, 1)
 	time.Sleep(100 * time.Millisecond)
-	if refreshUpstreamCount < 1 {
-		t.Fatalf("expected refresh for warm hit count (1), got %d upstream calls", refreshUpstreamCount)
+	if refreshUpstreamCount.Load() < 1 {
+		t.Fatalf("expected refresh for warm hit count (1), got %d upstream calls", refreshUpstreamCount.Load())
 	}
 }
 
@@ -2271,7 +2272,7 @@ func TestResolverWarmEntryRefreshFraction(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var refreshUpstreamCount int
+	var refreshUpstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -2291,7 +2292,7 @@ func TestResolverWarmEntryRefreshFraction(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		refreshUpstreamCount++
+		refreshUpstreamCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohSrv := newHTTPServer(dohHandler)
@@ -2342,8 +2343,8 @@ func TestResolverWarmEntryRefreshFraction(t *testing.T) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
-	if refreshUpstreamCount < 1 {
-		t.Errorf("expected warm entry refresh (1 hit, 14m remaining <= 15m from 0.25*1h), got %d calls", refreshUpstreamCount)
+	if refreshUpstreamCount.Load() < 1 {
+		t.Errorf("expected warm entry refresh (1 hit, 14m remaining <= 15m from 0.25*1h), got %d calls", refreshUpstreamCount.Load())
 	}
 }
 
@@ -2357,7 +2358,7 @@ func TestResolverRefreshPastAuthTTL(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var refreshUpstreamCount int
+	var refreshUpstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -2377,7 +2378,7 @@ func TestResolverRefreshPastAuthTTL(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		refreshUpstreamCount++
+		refreshUpstreamCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohSrv := newHTTPServer(dohHandler)
@@ -2431,8 +2432,8 @@ func TestResolverRefreshPastAuthTTL(t *testing.T) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
-	if refreshUpstreamCount < 1 {
-		t.Errorf("expected warm entry refresh when past auth TTL (storedTTL=1h, authTTL=60s, 1 hit), got %d calls", refreshUpstreamCount)
+	if refreshUpstreamCount.Load() < 1 {
+		t.Errorf("expected warm entry refresh when past auth TTL (storedTTL=1h, authTTL=60s, 1 hit), got %d calls", refreshUpstreamCount.Load())
 	}
 }
 
@@ -2622,7 +2623,7 @@ func TestResolverStartRefreshSweeper(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var upstreamCount int
+	var upstreamCount atomic.Int32
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", 405)
@@ -2642,7 +2643,7 @@ func TestResolverStartRefreshSweeper(t *testing.T) {
 		}
 		packed, _ := resp.Pack()
 		w.Header().Set("Content-Type", "application/dns-message")
-		upstreamCount++
+		upstreamCount.Add(1)
 		_, _ = w.Write(packed)
 	})
 	dohSrv := newHTTPServer(dohHandler)
@@ -2688,7 +2689,7 @@ func TestResolverStartRefreshSweeper(t *testing.T) {
 	// Sweeper should have run; with sweep_min_hits=0 the key is not deleted for being cold.
 	// The key may have been refreshed (scheduleRefresh -> refreshCache -> upstream).
 	// Just verify the sweeper ran without panicking and upstream may have been called.
-	if upstreamCount > 0 {
+	if upstreamCount.Load() > 0 {
 		// Refresh was scheduled and completed
 		return
 	}
@@ -3309,11 +3310,11 @@ func TestResolverGroupDisableCache(t *testing.T) {
 	blMgr := blocklist.NewManager(blCfg, logging.NewDiscardLogger())
 	blMgr.LoadOnce(nil)
 
-	var upstreamCount int
+	var upstreamCount atomic.Int32
 	var upstreamMu sync.Mutex
 	dohHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upstreamMu.Lock()
-		upstreamCount++
+		upstreamCount.Add(1)
 		upstreamMu.Unlock()
 		body, _ := io.ReadAll(r.Body)
 		req := new(dns.Msg)
@@ -3371,8 +3372,8 @@ func TestResolverGroupDisableCache(t *testing.T) {
 	w1 := &mockResponseWriter{remoteAddr: "192.168.1.11"}
 	resolver.ServeDNS(w1, req1)
 	upstreamMu.Lock()
-	if upstreamCount != 0 {
-		t.Errorf("normal group: expected cache hit (0 upstream calls), got %d", upstreamCount)
+	if upstreamCount.Load() != 0 {
+		t.Errorf("normal group: expected cache hit (0 upstream calls), got %d", upstreamCount.Load())
 	}
 	upstreamMu.Unlock()
 	if w1.written == nil || len(w1.written.Answer) == 0 {
@@ -3388,7 +3389,7 @@ func TestResolverGroupDisableCache(t *testing.T) {
 	w2 := &mockResponseWriter{remoteAddr: "192.168.1.10"}
 	resolver.ServeDNS(w2, req2)
 	upstreamMu.Lock()
-	gotUpstream := upstreamCount
+	gotUpstream := upstreamCount.Load()
 	upstreamMu.Unlock()
 	if gotUpstream != 1 {
 		t.Errorf("no-cache group: expected 1 upstream call (cache bypass), got %d", gotUpstream)

--- a/internal/dnsresolver/resolver_test.go
+++ b/internal/dnsresolver/resolver_test.go
@@ -32,7 +32,9 @@ type mockResponseWriter struct {
 	written    *dns.Msg
 }
 
-func (m *mockResponseWriter) LocalAddr() net.Addr { return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53} }
+func (m *mockResponseWriter) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53}
+}
 func (m *mockResponseWriter) RemoteAddr() net.Addr {
 	if m.remoteAddr != "" {
 		ip := net.ParseIP(m.remoteAddr)
@@ -48,9 +50,9 @@ func (m *mockResponseWriter) WriteMsg(msg *dns.Msg) error {
 }
 func (m *mockResponseWriter) Write([]byte) (int, error) { return 0, nil }
 func (m *mockResponseWriter) Close() error              { return nil }
-func (m *mockResponseWriter) TsigStatus() error        { return nil }
-func (m *mockResponseWriter) TsigTimersOnly(bool)     {}
-func (m *mockResponseWriter) Hijack()                  {}
+func (m *mockResponseWriter) TsigStatus() error         { return nil }
+func (m *mockResponseWriter) TsigTimersOnly(bool)       {}
+func (m *mockResponseWriter) Hijack()                   {}
 
 func TestResolverBlockedQuery(t *testing.T) {
 	// Blocklist with ads.example.com in denylist (no fetch needed)
@@ -482,9 +484,9 @@ func TestNormalizeQueryName(t *testing.T) {
 
 func TestParseUpstream(t *testing.T) {
 	tests := []struct {
-		name   string
-		u      config.UpstreamConfig
-		want   Upstream
+		name string
+		u    config.UpstreamConfig
+		want Upstream
 	}{
 		{"explicit udp", config.UpstreamConfig{Name: "u1", Address: "1.1.1.1:53", Protocol: "udp"}, Upstream{Name: "u1", Address: "1.1.1.1:53", Protocol: "udp"}},
 		{"explicit tls", config.UpstreamConfig{Name: "t1", Address: "1.1.1.1:853", Protocol: "tls"}, Upstream{Name: "t1", Address: "1.1.1.1:853", Protocol: "tls"}},
@@ -542,9 +544,9 @@ func TestResolveNetworkConfig(t *testing.T) {
 		validate := true
 		cfg := config.Config{
 			Network: config.NetworkConfig{
-				UpstreamTimeout:                 config.Duration{Duration: timeout},
-				UpstreamBackoff:                 &config.Duration{Duration: backoff},
-				UpstreamConnPoolIdleTimeout:     &config.Duration{Duration: idle},
+				UpstreamTimeout:                     config.Duration{Duration: timeout},
+				UpstreamBackoff:                     &config.Duration{Duration: backoff},
+				UpstreamConnPoolIdleTimeout:         &config.Duration{Duration: idle},
 				UpstreamConnPoolValidateBeforeReuse: &validate,
 			},
 		}
@@ -948,10 +950,10 @@ func TestRefreshUpstreamFailLogRateLimit(t *testing.T) {
 	cfg := minimalResolverConfig("https://127.0.0.1:19999/dns-query")
 	cfg.Blocklists = blCfg
 	cfg.Cache.Refresh = config.RefreshConfig{
-		Enabled:        ptr(true),
-		MaxInflight:    10,
-		MinTTL:         config.Duration{Duration: 1 * time.Second},
-		LockTTL:        config.Duration{Duration: 5 * time.Second},
+		Enabled:       ptr(true),
+		MaxInflight:   10,
+		MinTTL:        config.Duration{Duration: 1 * time.Second},
+		LockTTL:       config.Duration{Duration: 5 * time.Second},
 		HitWindow:     config.Duration{Duration: time.Minute},
 		SweepInterval: config.Duration{Duration: time.Hour},
 		SweepWindow:   config.Duration{Duration: time.Hour},
@@ -1018,10 +1020,10 @@ func TestUpstreamBackoffAllProtocols(t *testing.T) {
 	defer dohOkSrv.Close()
 
 	protocols := []struct {
-		name              string
-		fail              config.UpstreamConfig
-		ok                config.UpstreamConfig
-		timeout           time.Duration
+		name               string
+		fail               config.UpstreamConfig
+		ok                 config.UpstreamConfig
+		timeout            time.Duration
 		skipFailCountCheck bool // true when fail upstream has no server to count (e.g. unreachable DoQ)
 	}{
 		{
@@ -1062,8 +1064,8 @@ func TestUpstreamBackoffAllProtocols(t *testing.T) {
 			ok: config.UpstreamConfig{
 				Name: "doh-ok", Address: dohOkSrv.URL, Protocol: "https",
 			},
-			timeout:              500 * time.Millisecond,
-			skipFailCountCheck:   true, // unreachable address has no server to count
+			timeout:            500 * time.Millisecond,
+			skipFailCountCheck: true, // unreachable address has no server to count
 		},
 		{
 			name: "https",
@@ -1244,7 +1246,7 @@ func minimalResolverConfig(upstreamURL string) config.Config {
 		QueryStore: config.QueryStoreConfig{
 			Enabled: ptr(false),
 		},
-		Control: config.ControlConfig{},
+		Control:  config.ControlConfig{},
 		Webhooks: config.WebhooksConfig{},
 	}
 }
@@ -1577,17 +1579,17 @@ func TestResolverStaleEntryTTL(t *testing.T) {
 	cfg := minimalResolverConfig("https://invalid.invalid/dns-query")
 	cfg.Blocklists = blCfg
 	cfg.Cache.Refresh = config.RefreshConfig{
-		Enabled:          ptr(true),
-		ServeStale:       ptr(true),
-		StaleTTL:         config.Duration{Duration: time.Hour},
-		ExpiredEntryTTL:  config.Duration{Duration: 30 * time.Second},
-		LockTTL:          config.Duration{Duration: 5 * time.Second},
-		MaxInflight:      10,
-		SweepInterval:     config.Duration{Duration: time.Hour},
-		SweepWindow:      config.Duration{Duration: 30 * time.Minute},
-		MaxBatchSize:     100,
-		SweepMinHits:     0,
-		SweepHitWindow:   config.Duration{Duration: time.Hour},
+		Enabled:            ptr(true),
+		ServeStale:         ptr(true),
+		StaleTTL:           config.Duration{Duration: time.Hour},
+		ExpiredEntryTTL:    config.Duration{Duration: 30 * time.Second},
+		LockTTL:            config.Duration{Duration: 5 * time.Second},
+		MaxInflight:        10,
+		SweepInterval:      config.Duration{Duration: time.Hour},
+		SweepWindow:        config.Duration{Duration: 30 * time.Minute},
+		MaxBatchSize:       100,
+		SweepMinHits:       0,
+		SweepHitWindow:     config.Duration{Duration: time.Hour},
 		HitCountSampleRate: 1.0,
 	}
 
@@ -1965,7 +1967,7 @@ func TestResolverRefreshScheduled(t *testing.T) {
 	cfg.Upstreams = []config.UpstreamConfig{{Name: "doh", Address: dohSrv.URL, Protocol: "https"}}
 	cfg.Blocklists = blCfg
 	cfg.Cache.Refresh = config.RefreshConfig{
-		Enabled:           ptr(true),
+		Enabled:            ptr(true),
 		HitWindow:          config.Duration{Duration: time.Hour},
 		HotThreshold:       1,
 		HotThresholdRate:   0, // use absolute for test (1 hit = hot)
@@ -1976,7 +1978,7 @@ func TestResolverRefreshScheduled(t *testing.T) {
 		MaxInflight:        10,
 		SweepInterval:      config.Duration{Duration: time.Hour},
 		SweepWindow:        config.Duration{Duration: 30 * time.Minute},
-		MaxBatchSize:      100,
+		MaxBatchSize:       100,
 		SweepMinHits:       0,
 		SweepHitWindow:     config.Duration{Duration: time.Hour},
 		HitCountSampleRate: 1.0,
@@ -2056,7 +2058,7 @@ func TestResolverRootZoneNoRefresh(t *testing.T) {
 	cfg.Upstreams = []config.UpstreamConfig{{Name: "doh", Address: dohSrv.URL, Protocol: "https"}}
 	cfg.Blocklists = blCfg
 	cfg.Cache.Refresh = config.RefreshConfig{
-		Enabled:           ptr(true),
+		Enabled:            ptr(true),
 		HitWindow:          config.Duration{Duration: time.Hour},
 		HotThreshold:       1,
 		HotThresholdRate:   0,
@@ -2147,21 +2149,21 @@ func TestResolverWarmEntryRefresh(t *testing.T) {
 	cfg.Upstreams = []config.UpstreamConfig{{Name: "doh", Address: dohSrv.URL, Protocol: "https"}}
 	cfg.Blocklists = blCfg
 	cfg.Cache.Refresh = config.RefreshConfig{
-		Enabled:           ptr(true),
-		HitWindow:         config.Duration{Duration: time.Hour},
-		HotThreshold:      10,  // 1 hit is not hot
-		HotThresholdRate:  0,
-		MinTTL:            config.Duration{Duration: 30 * time.Second},
-		WarmThreshold:     2,
-		WarmTTL:           config.Duration{Duration: 5 * time.Minute},
-		ServeStale:        ptr(false),
-		LockTTL:           config.Duration{Duration: 5 * time.Second},
-		MaxInflight:       10,
-		SweepInterval:     config.Duration{Duration: time.Hour},
-		SweepWindow:       config.Duration{Duration: 30 * time.Minute},
-		MaxBatchSize:     100,
-		SweepMinHits:      0,
-		SweepHitWindow:    config.Duration{Duration: time.Hour},
+		Enabled:            ptr(true),
+		HitWindow:          config.Duration{Duration: time.Hour},
+		HotThreshold:       10, // 1 hit is not hot
+		HotThresholdRate:   0,
+		MinTTL:             config.Duration{Duration: 30 * time.Second},
+		WarmThreshold:      2,
+		WarmTTL:            config.Duration{Duration: 5 * time.Minute},
+		ServeStale:         ptr(false),
+		LockTTL:            config.Duration{Duration: 5 * time.Second},
+		MaxInflight:        10,
+		SweepInterval:      config.Duration{Duration: time.Hour},
+		SweepWindow:        config.Duration{Duration: 30 * time.Minute},
+		MaxBatchSize:       100,
+		SweepMinHits:       0,
+		SweepHitWindow:     config.Duration{Duration: time.Hour},
 		HitCountSampleRate: 1.0,
 	}
 
@@ -2311,22 +2313,22 @@ func TestResolverWarmEntryRefreshFraction(t *testing.T) {
 	cfg.Upstreams = []config.UpstreamConfig{{Name: "doh", Address: dohSrv.URL, Protocol: "https"}}
 	cfg.Blocklists = blCfg
 	cfg.Cache.Refresh = config.RefreshConfig{
-		Enabled:          ptr(true),
-		HitWindow:        config.Duration{Duration: time.Hour},
-		HotThreshold:     10,
-		HotThresholdRate: 0,
-		MinTTL:           config.Duration{Duration: 30 * time.Second},
-		WarmThreshold:    2,
-		WarmTTL:         config.Duration{Duration: 5 * time.Minute},
-		WarmTTLFraction: 0.25,
-		ServeStale:       ptr(false),
-		LockTTL:          config.Duration{Duration: 5 * time.Second},
-		MaxInflight:      10,
-		SweepInterval:    config.Duration{Duration: time.Hour},
-		SweepWindow:      config.Duration{Duration: 30 * time.Minute},
-		MaxBatchSize:     100,
-		SweepMinHits:     0,
-		SweepHitWindow:   config.Duration{Duration: time.Hour},
+		Enabled:            ptr(true),
+		HitWindow:          config.Duration{Duration: time.Hour},
+		HotThreshold:       10,
+		HotThresholdRate:   0,
+		MinTTL:             config.Duration{Duration: 30 * time.Second},
+		WarmThreshold:      2,
+		WarmTTL:            config.Duration{Duration: 5 * time.Minute},
+		WarmTTLFraction:    0.25,
+		ServeStale:         ptr(false),
+		LockTTL:            config.Duration{Duration: 5 * time.Second},
+		MaxInflight:        10,
+		SweepInterval:      config.Duration{Duration: time.Hour},
+		SweepWindow:        config.Duration{Duration: 30 * time.Minute},
+		MaxBatchSize:       100,
+		SweepMinHits:       0,
+		SweepHitWindow:     config.Duration{Duration: time.Hour},
 		HitCountSampleRate: 1.0,
 	}
 
@@ -2389,9 +2391,9 @@ func TestResolverRefreshPastAuthTTL(t *testing.T) {
 	mockCache.SetEntryWithStoredAndAuthTTL(
 		cacheKey("authpast.example.com", dns.TypeA, dns.ClassINET),
 		mustRR(t, "authpast.example.com. 3480 A 192.168.1.101"),
-		58*time.Minute,  // remaining
-		1*time.Hour,     // storedTTL (we extended with min_ttl)
-		60*time.Second,  // authTTL (upstream said 60s)
+		58*time.Minute, // remaining
+		1*time.Hour,    // storedTTL (we extended with min_ttl)
+		60*time.Second, // authTTL (upstream said 60s)
 	)
 
 	cfg := minimalResolverConfig(dohSrv.URL)
@@ -3150,8 +3152,8 @@ func TestQueryStoreExclusion(t *testing.T) {
 	cfg := minimalResolverConfig(dohSrv.URL)
 	cfg.Upstreams = []config.UpstreamConfig{{Name: "doh", Address: dohSrv.URL, Protocol: "https"}}
 	cfg.QueryStore = config.QueryStoreConfig{
-		Enabled:       ptr(true),
-		SampleRate:    1.0,
+		Enabled:        ptr(true),
+		SampleRate:     1.0,
 		ExcludeDomains: []string{"local", "localhost"},
 		ExcludeClients: []string{"192.168.1.99"},
 	}
@@ -3262,8 +3264,8 @@ func TestResolverPerGroupBlocklist(t *testing.T) {
 	}
 	cfg.ClientGroups = []config.ClientGroup{
 		{
-			ID: "kids",
-			Name: "Kids",
+			ID:        "kids",
+			Name:      "Kids",
 			Blocklist: &config.GroupBlocklistConfig{InheritGlobal: &inheritFalse},
 		},
 		{ID: "adults", Name: "Adults"},

--- a/internal/dnsresolver/upstream_manager.go
+++ b/internal/dnsresolver/upstream_manager.go
@@ -14,8 +14,12 @@ type upstreamManager struct {
 	strategy string
 	timeout  time.Duration
 
-	backoff     time.Duration
-	backoffMu   sync.RWMutex
+	// backoff is the upstream backoff duration in nanoseconds. It is accessed
+	// atomically because it is read on the per-query hot path (IsInBackoff,
+	// RecordBackoff under backoffMu) while ApplyConfig may rewrite it under
+	// m.mu; a plain field would be guarded by two different mutexes and race.
+	backoff      atomic.Int64
+	backoffMu    sync.RWMutex
 	backoffUntil map[string]time.Time
 
 	connPoolIdleTimeout         time.Duration
@@ -34,12 +38,12 @@ func newUpstreamManager(upstreams []Upstream, strategy string, timeout, backoff 
 		servers:                     upstreams,
 		strategy:                    strategy,
 		timeout:                     timeout,
-		backoff:                     backoff,
 		backoffUntil:                make(map[string]time.Time),
 		connPoolIdleTimeout:         connPoolIdle,
 		connPoolValidateBeforeReuse: connPoolValidate,
 		weightedLatency:             make(map[string]*float64),
 	}
+	m.backoff.Store(int64(backoff))
 	if strategy == StrategyWeighted {
 		for _, u := range upstreams {
 			init := 50.0
@@ -152,7 +156,7 @@ func (m *upstreamManager) UpdateWeightedLatency(address string, elapsed time.Dur
 
 // IsInBackoff returns true if the upstream address is in backoff.
 func (m *upstreamManager) IsInBackoff(addr string) bool {
-	if m.backoff <= 0 {
+	if m.backoff.Load() <= 0 {
 		return false
 	}
 	m.backoffMu.RLock()
@@ -168,7 +172,7 @@ func (m *upstreamManager) RecordBackoff(addr string) {
 	if m.backoffUntil == nil {
 		m.backoffUntil = make(map[string]time.Time)
 	}
-	m.backoffUntil[addr] = time.Now().Add(m.backoff)
+	m.backoffUntil[addr] = time.Now().Add(time.Duration(m.backoff.Load()))
 }
 
 // ClearBackoff removes backoff state for an upstream.
@@ -184,10 +188,10 @@ func (m *upstreamManager) ApplyConfig(upstreams []Upstream, strategy string, tim
 	m.servers = upstreams
 	m.strategy = strategy
 	m.timeout = timeout
-	m.backoff = backoff
 	m.connPoolIdleTimeout = connPoolIdle
 	m.connPoolValidateBeforeReuse = connPoolValidate
 	m.mu.Unlock()
+	m.backoff.Store(int64(backoff))
 
 	// Clear backoff for upstreams no longer in config
 	m.backoffMu.Lock()
@@ -223,9 +227,7 @@ func (m *upstreamManager) ApplyConfig(upstreams []Upstream, strategy string, tim
 
 // BackoffEnabled returns true if upstream backoff is configured.
 func (m *upstreamManager) BackoffEnabled() bool {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.backoff > 0
+	return m.backoff.Load() > 0
 }
 
 // Strategy returns the current resolver strategy.

--- a/internal/querystore/clickhouse_maintenance_test.go
+++ b/internal/querystore/clickhouse_maintenance_test.go
@@ -75,11 +75,11 @@ func newTestStore(serverURL string, maxSizeMB int) *ClickHouseStore {
 
 func TestGetTableSizeBytes(t *testing.T) {
 	tests := []struct {
-		name     string
-		status   int
-		body     string
-		want     int64
-		wantErr  bool
+		name    string
+		status  int
+		body    string
+		want    int64
+		wantErr bool
 	}{
 		{"normal size", http.StatusOK, "1048576\n", 1048576, false},
 		{"zero", http.StatusOK, "0", 0, false},

--- a/internal/querystore/clickhouse_maintenance_test.go
+++ b/internal/querystore/clickhouse_maintenance_test.go
@@ -1,0 +1,249 @@
+package querystore
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestIsValidPartitionID(t *testing.T) {
+	tests := []struct {
+		name      string
+		partition string
+		want      bool
+	}{
+		{"valid YYYYMMDD", "20240131", true},
+		{"valid YYYYMMDDHH", "2024013123", true},
+		{"empty", "", false},
+		{"too short", "2024013", false},
+		{"length 9", "202401311", false},
+		{"too long", "202401312345", false},
+		{"contains letter", "2024013a", false},
+		{"contains hyphen", "2024-013", false},
+		// SQL-injection style payloads must be rejected: this validator exists
+		// specifically to prevent injection from a crafted ClickHouse response.
+		{"injection drop", "1';DROP TABLE x;--", false},
+		{"injection quote", "20240131' OR '1'='1", false},
+		{"spaces", "2024 131", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidPartitionID(tt.partition); got != tt.want {
+				t.Errorf("isValidPartitionID(%q) = %v, want %v", tt.partition, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSchemaMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"unknown database", "Code: 81. DB::Exception: UNKNOWN_DATABASE", true},
+		{"unknown table", "Code: 60. UNKNOWN_TABLE: ...", true},
+		{"does not exist", "Table beyond.queries does not exist", true},
+		{"unrelated error", "Code: 241. MEMORY_LIMIT_EXCEEDED", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSchemaMissing(tt.body); got != tt.want {
+				t.Errorf("isSchemaMissing(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// newTestStore builds a ClickHouseStore wired to the given mock server URL
+// without running the migration logic in NewClickHouseStore.
+func newTestStore(serverURL string, maxSizeMB int) *ClickHouseStore {
+	return &ClickHouseStore{
+		client:    &http.Client{Timeout: 5 * time.Second},
+		baseURL:   serverURL,
+		database:  "beyond",
+		table:     "queries",
+		maxSizeMB: maxSizeMB,
+		logger:    slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+}
+
+func TestGetTableSizeBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		want     int64
+		wantErr  bool
+	}{
+		{"normal size", http.StatusOK, "1048576\n", 1048576, false},
+		{"zero", http.StatusOK, "0", 0, false},
+		{"empty body means zero", http.StatusOK, "", 0, false},
+		{"null marker means zero", http.StatusOK, "\\N", 0, false},
+		{"non-numeric body", http.StatusOK, "not-a-number", 0, true},
+		{"server error", http.StatusInternalServerError, "boom", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			store := newTestStore(server.URL, 0)
+			got, err := store.getTableSizeBytes()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got size=%d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("getTableSizeBytes() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOldestPartition(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{"partition returned", http.StatusOK, "2024013100\n", "2024013100", false},
+		{"no partitions", http.StatusOK, "", "", false},
+		{"server error", http.StatusInternalServerError, "boom", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			store := newTestStore(server.URL, 0)
+			got, err := store.getOldestPartition()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("getOldestPartition() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnforceMaxSize_DropsUntilUnderLimit(t *testing.T) {
+	var sizeCalls, dropCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		switch {
+		case strings.Contains(query, "sum(bytes_on_disk)"):
+			// First check is over the limit, second is under (after a drop).
+			n := atomic.AddInt32(&sizeCalls, 1)
+			w.WriteHeader(http.StatusOK)
+			if n == 1 {
+				w.Write([]byte("2097152")) // 2MB > 1MB limit
+			} else {
+				w.Write([]byte("0")) // under limit, stop
+			}
+		case strings.Contains(query, "SELECT partition"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("2024013100"))
+		case strings.Contains(query, "DROP PARTITION"):
+			atomic.AddInt32(&dropCalls, 1)
+			// Verify the partition was validated/quoted as expected.
+			if !strings.Contains(query, "DROP PARTITION '2024013100'") {
+				t.Errorf("unexpected drop query: %s", query)
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	store := newTestStore(server.URL, 1)
+	store.enforceMaxSize()
+
+	if got := atomic.LoadInt32(&dropCalls); got != 1 {
+		t.Errorf("expected exactly 1 DROP PARTITION, got %d", got)
+	}
+}
+
+func TestEnforceMaxSize_NoPartitionToDrop(t *testing.T) {
+	var dropCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		switch {
+		case strings.Contains(query, "sum(bytes_on_disk)"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("2097152")) // always over limit
+		case strings.Contains(query, "SELECT partition"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("")) // no partition available
+		case strings.Contains(query, "DROP PARTITION"):
+			atomic.AddInt32(&dropCalls, 1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	store := newTestStore(server.URL, 1)
+	store.enforceMaxSize() // must return without dropping or looping forever
+
+	if got := atomic.LoadInt32(&dropCalls); got != 0 {
+		t.Errorf("expected no DROP when no partition available, got %d", got)
+	}
+}
+
+func TestEnforceMaxSize_RejectsInvalidPartition(t *testing.T) {
+	var dropCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		switch {
+		case strings.Contains(query, "sum(bytes_on_disk)"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("2097152")) // over limit
+		case strings.Contains(query, "SELECT partition"):
+			w.WriteHeader(http.StatusOK)
+			// Crafted/garbage partition id that must be rejected before any DROP.
+			w.Write([]byte("1';DROP TABLE queries;--"))
+		case strings.Contains(query, "DROP PARTITION"):
+			atomic.AddInt32(&dropCalls, 1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	store := newTestStore(server.URL, 1)
+	store.enforceMaxSize()
+
+	if got := atomic.LoadInt32(&dropCalls); got != 0 {
+		t.Errorf("invalid partition id must not trigger a DROP, got %d drops", got)
+	}
+}

--- a/web/client/src/hooks/useApiPolling.test.jsx
+++ b/web/client/src/hooks/useApiPolling.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+vi.mock("../utils/apiClient.js", () => ({
+  api: { get: vi.fn() },
+}));
+
+import { api } from "../utils/apiClient.js";
+import { useApiPolling } from "./useApiPolling.js";
+
+describe("useApiPolling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fetches data on mount and clears loading", async () => {
+    api.get.mockResolvedValue({ count: 3 });
+    const { result } = renderHook(() => useApiPolling("/api/stats"));
+
+    await waitFor(() => expect(result.current.data).toEqual({ count: 3 }));
+    expect(result.current.error).toBe("");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it("does not fetch when disabled", async () => {
+    api.get.mockResolvedValue({});
+    renderHook(() => useApiPolling("/api/stats", { enabled: false }));
+    // Give effects a chance to run.
+    await Promise.resolve();
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when url is empty", async () => {
+    api.get.mockResolvedValue({});
+    renderHook(() => useApiPolling("", {}));
+    await Promise.resolve();
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("captures error messages from failed requests", async () => {
+    api.get.mockRejectedValue(new Error("nope"));
+    const { result } = renderHook(() => useApiPolling("/api/stats"));
+    await waitFor(() => expect(result.current.error).toBe("nope"));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("ignores AbortError without setting error state", async () => {
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    api.get.mockRejectedValue(abort);
+    const { result } = renderHook(() => useApiPolling("/api/stats"));
+    // Let the rejected promise settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.error).toBe("");
+  });
+
+  it("reload() re-fetches the latest data", async () => {
+    api.get.mockResolvedValue({ v: 1 });
+    const { result } = renderHook(() => useApiPolling("/api/stats"));
+    await waitFor(() => expect(result.current.data).toEqual({ v: 1 }));
+
+    api.get.mockResolvedValue({ v: 2 });
+    await act(async () => {
+      result.current.reload();
+    });
+    await waitFor(() => expect(result.current.data).toEqual({ v: 2 }));
+  });
+});

--- a/web/client/src/hooks/useDebounce.test.js
+++ b/web/client/src/hooks/useDebounce.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDebounce } from "./useDebounce.js";
+
+describe("useDebounce", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value immediately", () => {
+    const { result } = renderHook(() => useDebounce("hello", 300));
+    expect(result.current).toBe("hello");
+  });
+
+  it("only updates after the delay elapses", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ v }) => useDebounce(v, 300), {
+      initialProps: { v: "a" },
+    });
+
+    rerender({ v: "b" });
+    // Not yet past the delay: still the old value.
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe("b");
+  });
+
+  it("resets the timer on rapid changes (debounce)", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ v }) => useDebounce(v, 300), {
+      initialProps: { v: "a" },
+    });
+
+    rerender({ v: "b" });
+    act(() => vi.advanceTimersByTime(200));
+    rerender({ v: "c" });
+    act(() => vi.advanceTimersByTime(200));
+    // 400ms total elapsed but the timer reset at 200ms, so still old value.
+    expect(result.current).toBe("a");
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(result.current).toBe("c");
+  });
+});

--- a/web/client/src/hooks/useQueryFilters.test.js
+++ b/web/client/src/hooks/useQueryFilters.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useQueryFilters } from "./useQueryFilters.js";
+
+describe("useQueryFilters", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with empty filters and collapsed panel", () => {
+    const { result } = renderHook(() => useQueryFilters());
+    expect(result.current.filterSearch).toBe("");
+    expect(result.current.filterOutcome).toBe("");
+    expect(result.current.queryFiltersExpanded).toBe(false);
+  });
+
+  it("updates individual filter state via setters", () => {
+    const { result } = renderHook(() => useQueryFilters());
+    act(() => result.current.setFilterOutcome("blocked"));
+    act(() => result.current.setQueryFiltersExpanded(true));
+    expect(result.current.filterOutcome).toBe("blocked");
+    expect(result.current.queryFiltersExpanded).toBe(true);
+  });
+
+  it("debounces the search filter (300ms)", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useQueryFilters());
+
+    act(() => result.current.setFilterSearch("ads"));
+    // Immediate value updates, debounced value lags.
+    expect(result.current.filterSearch).toBe("ads");
+    expect(result.current.debouncedFilterSearch).toBe("");
+
+    act(() => vi.advanceTimersByTime(300));
+    expect(result.current.debouncedFilterSearch).toBe("ads");
+  });
+});

--- a/web/client/src/hooks/useSyncStatus.test.jsx
+++ b/web/client/src/hooks/useSyncStatus.test.jsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+// Mock the API client before importing the hook under test.
+vi.mock("../utils/apiClient.js", () => ({
+  api: { get: vi.fn() },
+}));
+
+import { api } from "../utils/apiClient.js";
+import { useSyncStatus } from "./useSyncStatus.js";
+
+describe("useSyncStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loads sync status on mount", async () => {
+    api.get.mockResolvedValue({ role: "primary" });
+    const { result } = renderHook(() => useSyncStatus());
+
+    await waitFor(() => expect(result.current.syncStatus).toEqual({ role: "primary" }));
+    expect(result.current.syncError).toBe("");
+  });
+
+  it("surfaces an error and clears status on failure", async () => {
+    api.get.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useSyncStatus());
+
+    await waitFor(() => expect(result.current.syncError).toBe("boom"));
+    expect(result.current.syncStatus).toBeNull();
+  });
+
+  it("refresh() re-fetches status on demand", async () => {
+    api.get.mockResolvedValue({ role: "replica" });
+    const { result } = renderHook(() => useSyncStatus());
+    await waitFor(() => expect(result.current.syncStatus).toEqual({ role: "replica" }));
+
+    api.get.mockResolvedValue({ role: "primary" });
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.syncStatus).toEqual({ role: "primary" });
+  });
+});


### PR DESCRIPTION
- CI now runs go test with -race and emits a coverage summary
- Cover isValidPartitionID (SQL-injection guard), isSchemaMissing,
  getTableSizeBytes, getOldestPartition, and enforceMaxSize paths
  (drop loop, no-partition, invalid-partition rejection)
- querystore coverage 59.1% -> 75.3%