### PR TITLE
Change rate limiting from opt-out to opt-in

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -24,11 +24,12 @@ resolver_strategy: failover
 #     upstreams:
 #       - name: router
 #         address: "192.168.1.1:53"
-# Per-client rate limit (enabled by default; loopback exempt). Clients over
-# the limit get REFUSED. Raise queries if a downstream forwarder aggregates
-# many devices behind one IP.
+# Per-client rate limit (disabled by default; loopback exempt). Set enabled: true
+# to opt in. Clients over the limit get REFUSED, so leave it off unless you need
+# it — a downstream forwarder that aggregates many devices behind one IP can trip
+# the limit and take those devices offline. Raise queries accordingly if enabled.
 # rate_limit:
-#   enabled: true
+#   enabled: false
 #   queries: 1000   # max queries per client IP per window
 #   window: "60s"
 # upstream_backoff: "30s"  # Skip upstream for this duration after connection/timeout failure (omit = 30s, "0" = disabled)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -319,7 +319,7 @@ type ServerConfig struct {
 // spoofed source under attack) can't monopolize the resolver or use it as an
 // amplification reflector. Loopback clients are always exempt.
 type RateLimitConfig struct {
-	Enabled *bool    `yaml:"enabled"` // default true
+	Enabled *bool    `yaml:"enabled"` // default false (opt-in)
 	Queries int      `yaml:"queries"` // max queries per client IP per window (default 1000)
 	Window  Duration `yaml:"window"`  // window size (default 60s)
 }
@@ -1251,7 +1251,7 @@ func applyDefaults(cfg *Config) {
 		cfg.Server.RefuseANY = boolPtr(true)
 	}
 	if cfg.RateLimit.Enabled == nil {
-		cfg.RateLimit.Enabled = boolPtr(true)
+		cfg.RateLimit.Enabled = boolPtr(false)
 	}
 	if cfg.RateLimit.Queries <= 0 {
 		cfg.RateLimit.Queries = 1000

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1127,6 +1127,41 @@ webhooks:
 	})
 }
 
+func TestRateLimitConfigDefault(t *testing.T) {
+	defaultPath := writeTempConfig(t, []byte(`
+server:
+  listen: ["127.0.0.1:53"]
+`))
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg, err := LoadWithFiles(defaultPath, "")
+		if err != nil {
+			t.Fatalf("LoadWithFiles: %v", err)
+		}
+		if cfg.RateLimit.Enabled == nil {
+			t.Fatal("expected rate_limit.enabled to be defaulted, got nil")
+		}
+		if *cfg.RateLimit.Enabled {
+			t.Fatal("expected rate_limit.enabled to default to false")
+		}
+	})
+	t.Run("opt-in via toggle", func(t *testing.T) {
+		overridePath := writeTempConfig(t, []byte(`
+rate_limit:
+  enabled: true
+`))
+		cfg, err := LoadWithFiles(defaultPath, overridePath)
+		if err != nil {
+			t.Fatalf("LoadWithFiles: %v", err)
+		}
+		if cfg.RateLimit.Enabled == nil || !*cfg.RateLimit.Enabled {
+			t.Fatal("expected rate_limit.enabled to be true when set")
+		}
+		if cfg.RateLimit.Queries != 1000 {
+			t.Fatalf("expected default queries 1000, got %d", cfg.RateLimit.Queries)
+		}
+	})
+}
+
 func TestWebhookMultipleTargets(t *testing.T) {
 	defaultPath := writeTempConfig(t, []byte(`
 server:

--- a/internal/dnsresolver/resolver.go
+++ b/internal/dnsresolver/resolver.go
@@ -502,7 +502,7 @@ func New(cfg config.Config, cacheClient cache.DNSCache, localRecordsManager *loc
 	r.blockCnameCloaking.Store(cnameCloakingEnabled(cfg))
 	r.refuseANY = cfg.Server.RefuseANY == nil || *cfg.Server.RefuseANY
 	r.forwarding = buildForwardingTable(cfg.ForwardingRules)
-	if cfg.RateLimit.Enabled == nil || *cfg.RateLimit.Enabled {
+	if cfg.RateLimit.Enabled != nil && *cfg.RateLimit.Enabled {
 		limit := cfg.RateLimit.Queries
 		if limit <= 0 {
 			limit = 1000


### PR DESCRIPTION
## Summary
This PR changes the rate limiting feature from being enabled by default to disabled by default, requiring explicit opt-in via configuration.

## Key Changes
- **Default behavior**: Rate limiting is now disabled by default (`enabled: false`) instead of enabled
- **Configuration**: Updated the example config to reflect the new default and clarify that rate limiting must be explicitly enabled
- **Logic**: Fixed the resolver initialization to only enable rate limiting when explicitly set to `true`, rather than enabling it when the value is `nil` or `true`
- **Documentation**: Updated comments in the code and config example to explain the opt-in nature and potential impacts of rate limiting on downstream forwarders that aggregate multiple devices behind a single IP

## Implementation Details
- The `RateLimitConfig.Enabled` field now defaults to `false` in `applyDefaults()`
- The resolver's rate limit initialization logic was corrected from `if cfg.RateLimit.Enabled == nil || *cfg.RateLimit.Enabled` to `if cfg.RateLimit.Enabled != nil && *cfg.RateLimit.Enabled`, ensuring rate limiting only activates when explicitly enabled
- Added comprehensive test coverage (`TestRateLimitConfigDefault`) to verify the new default behavior and opt-in mechanism
- Updated example configuration comments to warn about potential issues with rate limiting when enabled, particularly for aggregated downstream connections

https://claude.ai/code/session_01VyK13iQdJuLegpXyyZ12fu